### PR TITLE
fix: handle path binaries properly on windows (closes #117, #118)

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -172,7 +172,7 @@ func lookpath(file string) error { // custom lookpath function so we know if a c
 		if err == errNotExec {
 			return err
 		} else if err == nil {
-			return execName, nil
+			return nil
 		}
 	}
 

--- a/exec.go
+++ b/exec.go
@@ -139,7 +139,7 @@ func execCommand(cmd, old string) error {
 			return interp.NewExitStatus(exitcode)
 		}
 
-		err, execName := lookpath(args[0])
+		err := lookpath(args[0])
 		if err == errNotExec {
 			hooks.Em.Emit("command.no-perm", args[0])
 			return interp.NewExitStatus(126)
@@ -147,8 +147,6 @@ func execCommand(cmd, old string) error {
 			hooks.Em.Emit("command.not-found", args[0])
 			return interp.NewExitStatus(127)
 		}
-
-		args[0] = execName // windows, thanks
 
 		return interp.DefaultExecHandler(2 * time.Second)(ctx, args)
 	}
@@ -161,7 +159,7 @@ func execCommand(cmd, old string) error {
 	return err
 }
 
-func lookpath(file string) (error, string) { // custom lookpath function so we know if a command is found *and* is executable
+func lookpath(file string) error { // custom lookpath function so we know if a command is found *and* is executable
 	skip := []string{"./", "/", "../", "~/"}
 	for _, s := range skip {
 		if strings.HasPrefix(file, s) {
@@ -170,15 +168,15 @@ func lookpath(file string) (error, string) { // custom lookpath function so we k
 	}
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 		path := filepath.Join(dir, file)
-		err, execName := findExecutable(path)
+		err := findExecutable(path)
 		if err == errNotExec {
-			return err, ""
+			return err
 		} else if err == nil {
-			return nil, execName
+			return execName, nil
 		}
 	}
 
-	return os.ErrNotExist, ""
+	return os.ErrNotExist
 }
 
 func splitInput(input string) ([]string, string) {

--- a/execfile_unix.go
+++ b/execfile_unix.go
@@ -1,0 +1,19 @@
+// +build linux darwin
+
+package main
+
+import (
+	"path/filepath"
+	"os"
+)
+
+func findExecutable(path string) (error, string) {
+	f, err := os.Stat(path)
+	if err != nil {
+		return err, ""
+	}
+	if m := f.Mode(); !m.IsDir() && m & 0111 != 0 {
+		return nil, filepath.Base(path)
+	}
+	return errNotExec, ""
+}

--- a/execfile_unix.go
+++ b/execfile_unix.go
@@ -7,13 +7,13 @@ import (
 	"os"
 )
 
-func findExecutable(path string) (error, string) {
+func findExecutable(path string) error {
 	f, err := os.Stat(path)
 	if err != nil {
-		return err, ""
+		return err
 	}
 	if m := f.Mode(); !m.IsDir() && m & 0111 != 0 {
-		return nil, filepath.Base(path)
+		return nil
 	}
-	return errNotExec, ""
+	return errNotExec
 }

--- a/execfile_unix.go
+++ b/execfile_unix.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"path/filepath"
 	"os"
 )
 

--- a/execfile_windows.go
+++ b/execfile_windows.go
@@ -3,24 +3,25 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
 	"os"
 )
 
-func findExecutable(path string) (error, string) {
+func findExecutable(path string) error {
 	nameExt := filepath.Ext(path)
 
 	if nameExt == "" {
 		for _, ext := range filepath.SplitList(os.Getenv("PATHEXT")) {
 			_, err := os.Stat(path + ext)
-			if err != nil {
-				return nil, filepath.Base(path + ext)
+			if err == nil {
+				return nil
 			}
 		}
 	} else {
 		_, err := os.Stat(path)
-		return err, ""
+		return err
 	}
 
-	return errNotExec, ""
+	return errNotExec
 }

--- a/execfile_windows.go
+++ b/execfile_windows.go
@@ -1,0 +1,26 @@
+// +build windows
+
+package main
+
+import (
+	"path/filepath"
+	"os"
+)
+
+func findExecutable(path string) (error, string) {
+	nameExt := filepath.Ext(path)
+
+	if nameExt == "" {
+		for _, ext := range filepath.SplitList(os.Getenv("PATHEXT")) {
+			_, err := os.Stat(path + ext)
+			if err != nil {
+				return nil, filepath.Base(path + ext)
+			}
+		}
+	} else {
+		_, err := os.Stat(path)
+		return err, ""
+	}
+
+	return errNotExec, ""
+}

--- a/execfile_windows.go
+++ b/execfile_windows.go
@@ -3,14 +3,12 @@
 package main
 
 import (
-	"fmt"
 	"path/filepath"
 	"os"
 )
 
 func findExecutable(path string) error {
 	nameExt := filepath.Ext(path)
-
 	if nameExt == "" {
 		for _, ext := range filepath.SplitList(os.Getenv("PATHEXT")) {
 			_, err := os.Stat(path + ext)
@@ -18,10 +16,12 @@ func findExecutable(path string) error {
 				return nil
 			}
 		}
-	} else {
-		_, err := os.Stat(path)
-		return err
 	}
 
-	return errNotExec
+	_, err := os.Stat(path)
+	if err == nil {
+		return errNotExec
+	}
+
+	return os.ErrNotExist
 }


### PR DESCRIPTION
uses a proper way of getting executables in path on windows
if a name without extension is given (example `ls`) it looks at $PATHEXT to check if `ls` with any of those extensions exist

if a path with ext is given, it'll just try that only
