### PR TITLE
feat: control k to delete the rest of the line

### DIFF
--- a/readline/line.go
+++ b/readline/line.go
@@ -176,3 +176,9 @@ func (rl *Instance) deleteToBeginning() {
 	rl.line = rl.line[rl.pos:]
 	rl.pos = 0
 }
+
+func (rl *Instance) deleteToEnd() {
+	rl.resetVirtualComp(false)
+	// Keep everything before the cursor
+	rl.line = rl.line[:rl.pos]
+}

--- a/readline/readline.go
+++ b/readline/readline.go
@@ -189,6 +189,16 @@ func (rl *Instance) Readline() (string, error) {
 			rl.resetHelpers()
 			rl.updateHelpers()
 
+		case charCtrlK:
+			if rl.modeTabCompletion {
+				rl.resetVirtualComp(true)
+			}
+			// Delete everything after the cursor position
+			rl.saveBufToRegister(rl.line[rl.pos:])
+			rl.deleteToEnd()
+			rl.resetHelpers()
+			rl.updateHelpers()
+
 		case charBackspace, charBackspace2:
 			// When currently in history completion, we refresh and automatically
 			// insert the first (filtered) candidate, virtually


### PR DESCRIPTION
---
- [X] I have reviewed CONTRIBUTING.md.
- [X] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [X] I have documented any breaking changes according to [SemVer](https://semver.org/).
---
Adds Control k to delete rest of line like other readline things. Could prob move down to emacs binds now that I am looking at the code. 

EDIT: Looks like bash vi mode lets you do control k while in normal mode too but zsh vi mode does not (worth noting that zsh also doesnt let you do control u unless your in insert mode which then it works)