### PR TITLE
feat: added forwardword, backwordword and keybinds

### DIFF
--- a/readline/codes.go
+++ b/readline/codes.go
@@ -51,8 +51,12 @@ var (
 	seqDelete2      = string([]byte{27, 91, 80})
 	seqCtrlDelete   = string([]byte{27, 91, 51, 59, 53, 126})
 	seqCtrlDelete2  = string([]byte{27, 91, 77})
+	seqAltDelete    = string([]byte{27, 91, 51, 59, 51, 126})
 	seqShiftTab     = string([]byte{27, 91, 90})
 	seqAltQuote     = string([]byte{27, 34})  // Added for showing registers ^["
+	seqAltB         = string([]byte{27, 98})
+	seqAltD         = string([]byte{27, 100})
+	seqAltF         = string([]byte{27, 102})
 	seqAltR         = string([]byte{27, 114}) // Used for alternative history
 	seqAltBackspace = string([]byte{27, 127})
 )

--- a/readline/line.go
+++ b/readline/line.go
@@ -183,26 +183,41 @@ func (rl *Instance) deleteToEnd() {
 	rl.line = rl.line[:rl.pos]
 }
 
+// @TODO(Renzix): move to emacs sepecific file
 func (rl *Instance) emacsForwardWord(tokeniser tokeniser) (adjust int) {
-	// when emacs has more specific stuff, move this in a file with then
 	split, index, pos := tokeniser(rl.line, rl.pos)
 	if len(split) == 0 {
 		return
 	}
 
-	word := rTrimWhiteSpace(split[index])
+	word := strings.TrimSpace(split[index])
 
 	switch {
 	case len(split) == 0:
 		return
-	case index == len(split)-1 && pos >= len(word)-1:
-		return
-	case pos >= len(word)-1:
-		word = rTrimWhiteSpace(split[index+1])
-		adjust = len(split[index]) - pos
-		adjust += len(word)
+	case pos == len(word) && index != len(split)-1:
+		extrawhitespace := len(strings.TrimLeft(split[index], " ")) - len(word)
+		word = split[index+1]
+		adjust = len(word) + extrawhitespace
 	default:
 		adjust = len(word) - pos
+	}
+	return
+}
+
+func (rl *Instance) emacsBackwardWord(tokeniser tokeniser) (adjust int) {
+	split, index, pos := tokeniser(rl.line, rl.pos)
+	if len(split) == 0 {
+		return
+	}
+
+	switch {
+	case len(split) == 0:
+		return
+	case pos == 0 && index != 0:
+		adjust = len(split[index-1])
+	default:
+		adjust = pos
 	}
 	return
 }

--- a/readline/readline.go
+++ b/readline/readline.go
@@ -755,6 +755,34 @@ func (rl *Instance) escapeSeq(r []rune) {
 		rl.pos = len(rl.line)
 		rl.viUndoSkipAppend = true
 
+	case seqAltB:
+		if rl.modeTabCompletion {
+			return
+		}
+
+		// This is only available in Insert mode
+		if rl.modeViMode != VimInsert {
+			return
+		}
+
+		move := rl.emacsBackwardWord(tokeniseLine)
+		rl.moveCursorByAdjust(-move)
+		rl.updateHelpers()
+
+	case seqAltF:
+		if rl.modeTabCompletion {
+			return
+		}
+
+		// This is only available in Insert mode
+		if rl.modeViMode != VimInsert {
+			return
+		}
+
+		move := rl.emacsForwardWord(tokeniseLine)
+		rl.moveCursorByAdjust(move)
+		rl.updateHelpers()
+
 	case seqAltR:
 		rl.resetVirtualComp(false)
 		// For some modes only, if we are in vim Keys mode,
@@ -786,17 +814,21 @@ func (rl *Instance) escapeSeq(r []rune) {
 		rl.viDeleteByAdjust(rl.viJumpB(tokeniseLine))
 		rl.updateHelpers()
 
-	case seqCtrlDelete, seqCtrlDelete2:
+	case seqCtrlDelete, seqCtrlDelete2, seqAltD:
 		if rl.modeTabCompletion {
 			rl.resetVirtualComp(false)
-		}
-		// This is only available in Insert mode
-		if rl.modeViMode != VimInsert {
-			return
 		}
 		rl.saveToRegister(rl.emacsForwardWord(tokeniseLine))
 		// vi delete, emacs forward, funny huh
 		rl.viDeleteByAdjust(rl.emacsForwardWord(tokeniseLine))
+		rl.updateHelpers()
+
+	case seqAltDelete:
+		if rl.modeTabCompletion {
+			rl.resetVirtualComp(false)
+		}
+		rl.saveToRegister(-rl.emacsBackwardWord(tokeniseLine))
+		rl.viDeleteByAdjust(-rl.emacsBackwardWord(tokeniseLine))
 		rl.updateHelpers()
 
 	default:


### PR DESCRIPTION
Added emacsForwardWord and emacsBackwordWord which is used by M-f and
M-b directly. Also added M-d to ctrl delete and removed the bad old
function in favor of the fancy new one. Lastly I added alt delete which
deletes with emacsBackwordWord. Works identically to gnu readline

---
- [X] I have reviewed CONTRIBUTING.md.
- [X] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [X] I have documented any breaking changes according to [SemVer](https://semver.org/).
---

I prob did something wrong but here u go. Should work exactly like gnu readline except for the being able to do a multiple forward words in a single call (could be added easily) https://git.savannah.gnu.org/cgit/readline.git/tree/text.c#n480 . I prob should make this into multiple commits, yell at me if needed