### PR TITLE
fix: make macOS config path match Linux

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	// i honestly dont know what directories to use for this
 	switch runtime.GOOS {
-	case "linux":
+	case "linux", "darwin":
 		userDataDir = getenv("XDG_DATA_HOME", curuser.HomeDir + "/.local/share")
 	default:
 		// this is fine on windows, dont know about others
@@ -56,7 +56,7 @@ func main() {
 		defaultConfDir = filepath.Join(confDir, "hilbish")
 	} else {
 		// else do ~ substitution
-		defaultConfDir = expandHome(defaultConfDir)
+		defaultConfDir = filepath.Join(expandHome(defaultConfDir), "hilbish")
 	}
 	defaultConfPath = filepath.Join(defaultConfDir, "init.lua")
 	if defaultHistDir == "" {

--- a/vars.go
+++ b/vars.go
@@ -3,7 +3,6 @@ package main
 // String vars that are free to be changed at compile time
 var (
 	version = "v2.0.0"
-	defaultConfDir = "" // ~ will be substituted for home, path for user's default config
 	defaultHistDir = ""
 	commonRequirePaths = "';./libs/?/init.lua;./?/init.lua;./?/?.lua'"
 

--- a/vars_darwin.go
+++ b/vars_darwin.go
@@ -17,4 +17,5 @@ var (
 	dataDir = "/usr/local/share/hilbish"
 	preloadPath = dataDir + "/prelude/init.lua"
 	sampleConfPath = dataDir + "/.hilbishrc.lua" // Path to default/sample config
+	defaultConfDir = getenv("XDG_CONFIG_HOME", "~/.config")
 )

--- a/vars_linux.go
+++ b/vars_linux.go
@@ -17,4 +17,5 @@ var (
 	dataDir = "/usr/share/hilbish"
 	preloadPath = dataDir + "/prelude/init.lua"
 	sampleConfPath = dataDir + "/.hilbishrc.lua" // Path to default/sample config
+	defaultConfDir = ""
 )

--- a/vars_windows.go
+++ b/vars_windows.go
@@ -11,4 +11,5 @@ var (
 	dataDir = "~\\Appdata\\Roaming\\Hilbish" // ~ and \ gonna cry?
 	preloadPath = dataDir + "\\prelude\\init.lua"
 	sampleConfPath = dataDir + "\\hilbishrc.lua" // Path to default/sample config
+	defaultConfDir = ""
 )


### PR DESCRIPTION
Also moves some variables around in vars_\*.go to accommodate the fix.

---
- [x] I have reviewed CONTRIBUTING.md.
- [x] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] I have documented any breaking changes according to [SemVer](https://semver.org/).
---
