### PR TITLE
fix: Not loading nature module on some systems

### DIFF
--- a/nature/init.lua
+++ b/nature/init.lua
@@ -2,7 +2,7 @@
 local _ = require 'succulent' -- Function additions
 
 package.path = package.path .. ';' .. hilbish.dataDir .. '/?/init.lua'
-.. ';' .. hilbish.dataDir .. '/?/?.lua'
+.. ';' .. hilbish.dataDir .. '/?/?.lua' .. ";" .. hilbish.dataDir .. '/?.lua'
 
 require 'nature.commands'
 require 'nature.completions'


### PR DESCRIPTION
Missing nature module, some functionality and builtins will be missing.
local error: open nature/init.lua: no such file or directory
global install error: error: /usr/share/hilbish/nature/commands/init.lua:2: could not find package 'nature.commands.cd'
~ cd Local
hilbish: cd not found

---
- [x] I have reviewed CONTRIBUTING.md.
- [x] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] I have documented any breaking changes according to [SemVer](https://semver.org/).
---

should also fix // https://github.com/Rosettea/Hilbish/issues/149 I think(i don't know their exact error)? I was having a similar issue. I don't know why it works for you and not for me (or some others)