### PR TITLE
feat: extend hilbish.runner interface to allow multiple runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ includes git commit, branch, and (new!!) release name.
 - Added `fg` and `bg` builtins
 - `job.foreground()` and `job.background()`, when `job` is a job object,
 foreground and backgrounds a job respectively.
+- Friendlier functions to the `hilbish.runner` interface, which also allow
+having and using multiple runners.
 
 ### Changed
 - **Breaking Change:** Upgraded to Lua 5.4.

--- a/docs/runner-mode.txt
+++ b/docs/runner-mode.txt
@@ -35,8 +35,21 @@ The exit code has to be a number, it will be 0 otherwise and the error can be
 `nil` to indicate no error.
 
 ## Functions
-These are the functions for the `hilbish.runner` interface
+These are the "low level" functions for the `hilbish.runner` interface.
 
 + setMode(mode) > The same as `hilbish.runnerMode`
 + sh(input) -> input, code, err > Runs `input` in Hilbish's sh interpreter
 + lua(input) -> input, code, err > Evals `input` as Lua code
+
+The others here are defined in Lua and have EmmyLua documentation.
+These functions should be preferred over the previous ones.
++ setCurrent(mode) > The same as `setMode`, but works with runners managed
+via the functions below.
++ add(name, runner) > Adds a runner to a table of available runners. The `runner`
+argument is either a function or a table with a run callback.
++ set(name, runner) > The same as `add` but requires passing a table and
+overwrites if the `name`d runner already exists.
++ get(name) > runner > Gets a runner by name. It is a table with at least a
+run function, to run input.
++ exec(cmd, runnerName) > Runs `cmd` with a runner. If `runnerName` isn't passed,
+the current runner mode is used.

--- a/nature/init.lua
+++ b/nature/init.lua
@@ -8,6 +8,7 @@ require 'nature.commands'
 require 'nature.completions'
 require 'nature.opts'
 require 'nature.vim'
+require 'nature.runner'
 
 local shlvl = tonumber(os.getenv 'SHLVL')
 if shlvl ~= nil then

--- a/nature/runner.lua
+++ b/nature/runner.lua
@@ -48,19 +48,9 @@ function runnerHandler.exec(cmd, runnerName)
 	return r.run(cmd)
 end
 
-
+-- lsp shut up
+hilbish = hilbish
 function runnerHandler.setCurrent(name)
-	local defaultRunners = {
-		hybrid = true,
-		hybridRev = true,
-		lua = true,
-		sh = true
-	}
-	if defaultRunners[name] then
-		hilbish.runner.setMode(name)
-		return
-	end
-
 	local r = runnerHandler.get(name)
 	currentRunner = name
 
@@ -69,4 +59,34 @@ end
 
 -- add functions to hilbish.runner
 for k, v in pairs(runnerHandler) do hilbish.runner[k] = v end
+
+runnerHandler.add('hybrid', function(input)
+	local cmdStr = hilbish.aliases.resolve(input)
+
+	local _, _, err = hilbish.runner.lua(cmdStr)
+	if not err then
+		return input, 0, nil
+	end
+
+	return hilbish.runner.sh(input)
+end)
+
+runnerHandler.add('hybridRev', function(input)
+	local _, _, err = hilbish.runner.sh(input)
+	if not err then
+		return input, 0, nil
+	end
+
+	local cmdStr = hilbish.aliases.resolve(input)
+	return hilbish.runner.lua(cmdStr)
+end)
+
+runnerHandler.add('lua', function(input)
+	local cmdStr = hilbish.aliases.resolve(input)
+	return hilbish.runner.lua(cmdStr)
+end)
+
+runnerHandler.add('sh', function(input)
+	return hilbish.runner.sh(input)
+end)
 

--- a/nature/runner.lua
+++ b/nature/runner.lua
@@ -51,10 +51,10 @@ end
 
 function runnerHandler.setCurrent(name)
 	local defaultRunners = {
-		'hybrid',
-		'hybridRev',
-		'lua',
-		'sh'
+		hybrid = true,
+		hybridRev = true,
+		lua = true,
+		sh = true
 	}
 	if defaultRunners[name] then
 		hilbish.runner.setMode(name)

--- a/nature/runner.lua
+++ b/nature/runner.lua
@@ -2,6 +2,9 @@ local currentRunner = 'hybrid'
 local runnerHandler = {}
 local runners = {}
 
+--- Get a runner by name.
+--- @param name string
+--- @return table
 function runnerHandler.get(name)
 	local r = runners[name]
 
@@ -12,6 +15,10 @@ function runnerHandler.get(name)
 	return r
 end
 
+--- Adds a runner to the table of available runners. If runner is a table,
+--- it must have the run function in it.
+--- @param name string
+--- @param runner function | table
 function runnerHandler.add(name, runner)
 	if type(name) ~= 'string' then
 		error 'expected runner name to be a table'
@@ -32,6 +39,9 @@ function runnerHandler.add(name, runner)
 	runnerHandler.set(name, runner)
 end
 
+--- Sets a runner by name. The runner table must have the run function in it.
+--- @param name string
+--- @param runner table
 function runnerHandler.set(name, runner)
 	if not runner.run or type(runner.run) ~= 'function' then
 		error 'run function in runner missing'
@@ -40,6 +50,11 @@ function runnerHandler.set(name, runner)
 	runners[name] = runner
 end
 
+--- Executes cmd with a runner. If runnerName isn't passed, it uses
+--- the user's current runner.
+--- @param cmd string
+--- @param runnerName string?
+--- @return string, number, string
 function runnerHandler.exec(cmd, runnerName)
 	if not runnerName then runnerName = currentRunner end
 
@@ -50,6 +65,8 @@ end
 
 -- lsp shut up
 hilbish = hilbish
+--- Sets the current interactive/command line runner mode.
+--- @param name string
 function runnerHandler.setCurrent(name)
 	local r = runnerHandler.get(name)
 	currentRunner = name

--- a/nature/runner.lua
+++ b/nature/runner.lua
@@ -48,7 +48,19 @@ function runnerHandler.exec(cmd, runnerName)
 	return r.run(cmd)
 end
 
+
 function runnerHandler.setCurrent(name)
+	local defaultRunners = {
+		'hybrid',
+		'hybridRev',
+		'lua',
+		'sh'
+	}
+	if defaultRunners[name] then
+		hilbish.runner.setMode(name)
+		return
+	end
+
 	local r = runnerHandler.get(name)
 	currentRunner = name
 

--- a/nature/runner.lua
+++ b/nature/runner.lua
@@ -68,5 +68,5 @@ function runnerHandler.setCurrent(name)
 end
 
 -- add functions to hilbish.runner
-for k, v in ipairs(runnerHandler) do hilbish.runner[k] = v end
+for k, v in pairs(runnerHandler) do hilbish.runner[k] = v end
 

--- a/nature/runner.lua
+++ b/nature/runner.lua
@@ -1,11 +1,13 @@
 local currentRunner = 'hybrid'
-local runnerHandler = {}
 local runners = {}
+
+-- lsp shut up
+hilbish = hilbish
 
 --- Get a runner by name.
 --- @param name string
 --- @return table
-function runnerHandler.get(name)
+function hilbish.runner.get(name)
 	local r = runners[name]
 
 	if not r then
@@ -19,7 +21,7 @@ end
 --- it must have the run function in it.
 --- @param name string
 --- @param runner function | table
-function runnerHandler.add(name, runner)
+function hilbish.runner.add(name, runner)
 	if type(name) ~= 'string' then
 		error 'expected runner name to be a table'
 	end
@@ -36,13 +38,13 @@ function runnerHandler.add(name, runner)
 		error(string.format('runner %s already exists', name))
 	end
 
-	runnerHandler.set(name, runner)
+	hilbish.runner.set(name, runner)
 end
 
 --- Sets a runner by name. The runner table must have the run function in it.
 --- @param name string
 --- @param runner table
-function runnerHandler.set(name, runner)
+function hilbish.runner.set(name, runner)
 	if not runner.run or type(runner.run) ~= 'function' then
 		error 'run function in runner missing'
 	end
@@ -55,29 +57,24 @@ end
 --- @param cmd string
 --- @param runnerName string?
 --- @return string, number, string
-function runnerHandler.exec(cmd, runnerName)
+function hilbish.runner.exec(cmd, runnerName)
 	if not runnerName then runnerName = currentRunner end
 
-	local r = runnerHandler.get(runnerName)
+	local r = hilbish.runner.get(runnerName)
 
 	return r.run(cmd)
 end
 
--- lsp shut up
-hilbish = hilbish
 --- Sets the current interactive/command line runner mode.
 --- @param name string
-function runnerHandler.setCurrent(name)
-	local r = runnerHandler.get(name)
+function hilbish.runner.setCurrent(name)
+	local r = hilbish.runner.get(name)
 	currentRunner = name
 
 	hilbish.runner.setMode(r.run)
 end
 
--- add functions to hilbish.runner
-for k, v in pairs(runnerHandler) do hilbish.runner[k] = v end
-
-runnerHandler.add('hybrid', function(input)
+hilbish.runner.add('hybrid', function(input)
 	local cmdStr = hilbish.aliases.resolve(input)
 
 	local _, _, err = hilbish.runner.lua(cmdStr)
@@ -88,7 +85,7 @@ runnerHandler.add('hybrid', function(input)
 	return hilbish.runner.sh(input)
 end)
 
-runnerHandler.add('hybridRev', function(input)
+hilbish.runner.add('hybridRev', function(input)
 	local _, _, err = hilbish.runner.sh(input)
 	if not err then
 		return input, 0, nil
@@ -98,12 +95,12 @@ runnerHandler.add('hybridRev', function(input)
 	return hilbish.runner.lua(cmdStr)
 end)
 
-runnerHandler.add('lua', function(input)
+hilbish.runner.add('lua', function(input)
 	local cmdStr = hilbish.aliases.resolve(input)
 	return hilbish.runner.lua(cmdStr)
 end)
 
-runnerHandler.add('sh', function(input)
+hilbish.runner.add('sh', function(input)
 	return hilbish.runner.sh(input)
 end)
 

--- a/nature/runner.lua
+++ b/nature/runner.lua
@@ -1,0 +1,56 @@
+local currentRunner = 'hybrid'
+local runnerHandler = {}
+local runners = {}
+
+function runnerHandler.get(name)
+	local r = runners[name]
+
+	if not r then
+		error(string.format('runner %s does not exist', name))
+	end
+
+	return r
+end
+
+function runnerHandler.add(name, runner)
+	if type(name) ~= 'string' then
+		error 'expected runner name to be a table'
+	end
+
+	if type(runner) ~= 'table' then
+		error 'expected runner to be a table'
+	end
+
+	if runners[name] then
+		error(string.format('runner %s already exists', name))
+	end
+
+	runnerHandler.set(name, runner)
+end
+
+function runnerHandler.set(name, runner)
+	if not runner.run or type(runner.run) ~= 'function' then
+		error 'run function in runner missing'
+	end
+
+	runners[name] = runner
+end
+
+function runnerHandler.exec(cmd, runnerName)
+	if not runnerName then runnerName = currentRunner end
+
+	local r = runnerHandler.get(runnerName)
+
+	return r.run(cmd)
+end
+
+function runnerHandler.setCurrent(name)
+	local r = runnerHandler.get(name)
+	currentRunner = name
+
+	hilbish.runner.setMode(r.run)
+end
+
+-- add functions to hilbish.runner
+for k, v in ipairs(runnerHandler) do hilbish.runner[k] = v end
+

--- a/nature/runner.lua
+++ b/nature/runner.lua
@@ -17,8 +17,12 @@ function runnerHandler.add(name, runner)
 		error 'expected runner name to be a table'
 	end
 
+	if type(runner) == 'function' then
+		runner = {run = runner} -- this probably looks confusing
+	end
+
 	if type(runner) ~= 'table' then
-		error 'expected runner to be a table'
+		error 'expected runner to be a table or function'
 	end
 
 	if runners[name] then


### PR DESCRIPTION
closes #158 
adds some additional functions to the hilbish.runner interface via lua.
allows getting, adding and replacing runners and setting them as the interactive command runner by name.