### PR TITLE
build: return Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 🎀 Changelog
 
 ## Unreleased
-**NOTE:** Hilbish now uses [Task] insead of Make for builds.
+**NOTE:** Hilbish now uses [Task] insead of Make for builds. Make is still available as a build method.
 
 [Task]: https://taskfile.dev/#/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+PREFIX ?= /usr
+BINDIR ?= $(PREFIX)/bin
+LIBDIR ?= $(PREFIX)/share/hilbish
+
+MY_GOFLAGS = -ldflags "-s -w"
+
+all: dev
+
+dev: MY_GOFLAGS = -ldflags "-s -w -X main.gitCommit=$(shell git rev-parse --short HEAD) -X main.gitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
+dev: build
+
+build:
+	go build $(MY_GOFLAGS)
+
+install:
+	install -v -d "$(DESTDIR)$(BINDIR)/" && install -m 0755 -v hilbish "$(DESTDIR)$(BINDIR)/hilbish"
+	mkdir -p "$(DESTDIR)$(LIBDIR)"
+	cp -r libs docs emmyLuaDocs nature .hilbishrc.lua "$(DESTDIR)$(LIBDIR)"
+	grep -qxF "$(DESTDIR)$(BINDIR)/hilbish" /etc/shells || echo "$(DESTDIR)$(BINDIR)/hilbish" >> /etc/shells
+
+uninstall:
+	rm -vrf \
+			"$(DESTDIR)$(BINDIR)/hilbish" \
+			"$(DESTDIR)$(LIBDIR)"
+	sed -i '/hilbish/d' /etc/shells
+
+clean:
+	go clean
+
+.PHONY: all dev build install uninstall clean


### PR DESCRIPTION
Maintaining a Makefile isn’t that big of a deal, then why remove it? Can we just keep it alongside the new Task?
---
- [x ] I have reviewed CONTRIBUTING.md.
- [ x] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x ] I have documented changes and additions in the CHANGELOG.md.
---
