### PR TITLE
fix: add missing gcc dependency to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If you're new to nix you should probably read up on how to do that [here](https:
 ### Prerequisites
 - [Go 1.17+](https://go.dev)
 - [Task](https://taskfile.dev/#/)
+- [gcc](https://gcc.gnu.org/)
 
 ### Build
 First, clone Hilbish. The recursive is required, as some Lua libraries


### PR DESCRIPTION
---
- [x] I have reviewed CONTRIBUTING.md.
- [x] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [ ] I have documented changes and additions in the CHANGELOG.md.
---
