### PR TITLE
fix: provide correct command when navigating history 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ will result in the files being completed.
 - Fix completion search menu disappearing
 - Completion paths having duplicated characters if it's escaped
 - Get custom completion command properly to call from Lua
+- Put proper command on the line when using up and down arrow keys to go through command history
 
 ## [2.0.0-rc1] - 2022-09-14
 This is a pre-release version of Hilbish for testing. To see the changelog,

--- a/readline/history.go
+++ b/readline/history.go
@@ -123,23 +123,20 @@ func (rl *Instance) walkHistory(i int) {
 
 	// When we are exiting the current line buffer to move around
 	// the history, we make buffer the current line
-	if rl.histPos == 0 && (rl.histPos+i) == 1 {
+	if rl.histOffset == 0 && rl.histOffset + i == 1 {
 		rl.lineBuf = string(rl.line)
 	}
 
-	switch rl.histPos + i {
-	case 0, history.Len() + 1:
-		rl.histPos = 0
+	rl.histOffset += i
+	if rl.histOffset == 0 {
 		rl.line = []rune(rl.lineBuf)
 		rl.pos = len(rl.lineBuf)
-		return
-	case -1:
-		rl.histPos = 0
-		rl.lineBuf = string(rl.line)
-	default:
+	} else if rl.histOffset <= -1 {
+		rl.histOffset = 0
+	} else {
 		dedup = true
 		old = string(rl.line)
-		new, err = history.GetLine(history.Len() - rl.histPos - 1)
+		new, err = history.GetLine(history.Len() - rl.histOffset)
 		if err != nil {
 			rl.resetHelpers()
 			print("\r\n" + err.Error() + "\r\n")
@@ -148,7 +145,6 @@ func (rl *Instance) walkHistory(i int) {
 		}
 
 		rl.clearLine()
-		rl.histPos += i
 		rl.line = []rune(new)
 		rl.pos = len(rl.line)
 		if rl.pos > 0 {

--- a/readline/instance.go
+++ b/readline/instance.go
@@ -134,6 +134,7 @@ type Instance struct {
 	// history operating params
 	lineBuf    string
 	histPos    int
+	histOffset int
 	histNavIdx int // Used for quick history navigation.
 
 	//

--- a/readline/readline.go
+++ b/readline/readline.go
@@ -49,7 +49,7 @@ func (rl *Instance) Readline() (string, error) {
 
 	// History Init
 	// We need this set to the last command, so that we can access it quickly
-	rl.histPos = 0
+	rl.histOffset = 0
 	rl.viUndoHistory = []undoItem{{line: "", pos: 0}}
 
 	// Multisplit


### PR DESCRIPTION
---
- [x] I have reviewed CONTRIBUTING.md.
- [x] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] I have documented changes and additions in the CHANGELOG.md.
---

fixes an issue of going up and down in history results in the incorrect order of commands being inserted (nothing happens to the order in the history itself, just when navigating via arrow keys)
