### PR TITLE
build!: set datadir of hilbish properly if PREFIX or LIBDIR changes

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -3,19 +3,19 @@
 version: '3'
 
 vars:
-  PREFIX: '{{default "/usr" .PREFIX}}'
+  PREFIX: '{{default "/usr/local" .PREFIX}}'
   bindir__: '{{.PREFIX}}/bin'
   BINDIR: '{{default .bindir__ .BINDIR}}'
   libdir__: '{{.PREFIX}}/share/hilbish'
   LIBDIR: '{{default .libdir__ .LIBDIR}}'
-  GOFLAGS: '-ldflags "-s -w"'
+  GOFLAGS: '-ldflags "-s -w -X main.dataDir={{.LIBDIR}}"'
 
 tasks:
   default:
     cmds:
       - CGO_ENABLED=0 go build {{.GOFLAGS}}
     vars:
-      GOFLAGS: '-ldflags "-s -w -X main.gitCommit=$(git rev-parse --short HEAD) -X main.gitBranch=$(git rev-parse --abbrev-ref HEAD)"'
+      GOFLAGS: '-ldflags "-s -w -X main.dataDir={{.LIBDIR}} -X main.gitCommit=$(git rev-parse --short HEAD) -X main.gitBranch=$(git rev-parse --abbrev-ref HEAD)"'
 
   build:
     cmds:

--- a/vars_linux.go
+++ b/vars_linux.go
@@ -14,7 +14,7 @@ var (
 	.. hilbish.userDir.config	.. '/hilbish/?/init.lua;'
 	.. hilbish.userDir.config	.. '/hilbish/?/?.lua;'
 	.. hilbish.userDir.config	.. '/hilbish/?.lua'`
-	dataDir = "/usr/share/hilbish"
+	dataDir = "/usr/local/share/hilbish"
 	preloadPath = dataDir + "/nature/init.lua"
 	sampleConfPath = dataDir + "/.hilbishrc.lua" // Path to default/sample config
 	defaultConfDir = ""


### PR DESCRIPTION
this ensures hilbish always uses the correct datadir and gets installed to the right location on non-linux. this pr also changes the default install location of unix-like to `/usr/local`

---
- [x] I have reviewed CONTRIBUTING.md.
- [x] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [ ] I have documented changes and additions in the CHANGELOG.md.
---
