### PR TITLE
feat: multiline support

### DIFF
--- a/readline/prompt.go
+++ b/readline/prompt.go
@@ -218,3 +218,11 @@ func (rl *Instance) echoRightPrompt() {
 		print(rl.rightPrompt)
 	}
 }
+
+func (rl *Instance) getPromptPos() int {
+	if !rl.Multiline {
+		return getRealLength(rl.mainPrompt)
+	} else {
+		return getRealLength(rl.MultilinePrompt)
+	}
+}

--- a/readline/vim.go
+++ b/readline/vim.go
@@ -238,11 +238,11 @@ func (rl *Instance) vi(r rune) {
 	case 'v':
 		rl.clearHelpers()
 		var multiline []rune
-		if rl.GetMultiLine == nil {
+		/*if rl.GetMultiLine == nil {
 			multiline = rl.line
 		} else {
 			multiline = rl.GetMultiLine(rl.line)
-		}
+		}*/
 
 		// Keep the previous cursor position
 		//prev := rl.pos


### PR DESCRIPTION
closes #182 

this effectively copies and "backports" the fix for multiline editing from the work done at the upstream library in https://github.com/reeflective/readline/pull/24 and the reason for doing this is due to the fact that the upstream version is not desirable for use in hilbish (yet)