### PR TITLE
feat: allow numbered substitutions in aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - `hilbish.notification` signal when a message/notification is sent
 - `notifyJobFinish` opt to send a notification when background jobs are
 completed.
+- Allow numbered arg substitutions in aliases.
+  - Example: `hilbish.alias('hello', 'echo %1 says hello')` allows the user to run `hello hilbish`
+  which will output `hilbish says hello`.
 
 [#219]: https://github.com/Rosettea/Hilbish/issues/219
 ### Fixed

--- a/aliases.go
+++ b/aliases.go
@@ -54,12 +54,12 @@ func (a *aliasModule) Resolve(cmdstr string) string {
 	for a.aliases[args[0]] != "" {
 		alias := a.aliases[args[0]]
 		alias = arg.ReplaceAllStringFunc(alias, func(a string) string {
-			if strings.HasPrefix(a, "\\") {
+			idx, _ := strconv.Atoi(a[1:])
+			if strings.HasPrefix(a, "\\") || idx == 0 {
 				return strings.TrimPrefix(a, "\\")
 			}
 
-			idx, _ := strconv.Atoi(a[1:])
-			if idx > len(args) {
+			if idx + 1 > len(args) {
 				return a
 			}
 			val := args[idx]

--- a/aliases.go
+++ b/aliases.go
@@ -50,7 +50,7 @@ func (a *aliasModule) Resolve(cmdstr string) string {
 
 	arg, _ := regexp.Compile(`[\\]?%\d+`)
 
-	args := strings.Split(cmdstr, " ")
+	args, _ := splitInput(cmdstr)
 	for a.aliases[args[0]] != "" {
 		alias := a.aliases[args[0]]
 		alias = arg.ReplaceAllStringFunc(alias, func(a string) string {

--- a/main.go
+++ b/main.go
@@ -324,3 +324,7 @@ func getVersion() string {
 
 	return v.String()
 }
+
+func cut(slice []string, idx int) []string {
+	return append(slice[:idx], slice[idx + 1:]...)
+}


### PR DESCRIPTION
this allows users to refer to args in aliases with an index. this makes it so certain aliases don't have to be done via a commander

example:
```
~/Files/Projects/Hilbish alias-substitute*                                   
∆ hilbish.alias('dumb', 'echo %1 is dumb')
~/Files/Projects/Hilbish alias-substitute*                                   
∆ dumb
%1 is dumb
~/Files/Projects/Hilbish alias-substitute*                                   
∆ dumb me
me is dumb
```

---
- [x] I have reviewed CONTRIBUTING.md.
- [x] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] I have documented changes and additions in the CHANGELOG.md.
---
