### PR TITLE
refactor: move hilbish.editor function impls to readline side

### DIFF
--- a/cmd/docgen/docgen.go
+++ b/cmd/docgen/docgen.go
@@ -268,7 +268,7 @@ func main() {
 	os.Mkdir("docs/api", 0777)
 	os.Mkdir("emmyLuaDocs", 0777)
 
-	dirs := []string{"./"}
+	dirs := []string{"./readline", "./"}
 	filepath.Walk("golibs/", func (path string, info os.FileInfo, err error) error {
 		if !info.IsDir() {
 			return nil
@@ -295,7 +295,7 @@ func main() {
 		pieces := []docPiece{}
 		typePieces := []docPiece{}
 		mod := l
-		if mod == "main" {
+		if mod == "main" || mod == "readline" {
 			mod = "hilbish"
 		}
 		var hasInterfaces bool
@@ -457,6 +457,9 @@ func main() {
 					htmlSig := typeTag.ReplaceAllStringFunc(strings.Replace(dps.FuncSig, "<", `\<`, -1), func(typ string) string {
 						typName := typ[1:]
 						typLookup := typeTable[strings.ToLower(typName)]
+						if len(typLookup) == 0 {
+							typLookup = []string{"WHAT", "WHAT"}
+						}
 						ifaces := typLookup[0] + "." + typLookup[1] + "/"
 						if typLookup[1] == "" {
 							ifaces = ""

--- a/docs/api/hilbish/hilbish.editor.md
+++ b/docs/api/hilbish/hilbish.editor.md
@@ -12,15 +12,6 @@ The hilbish.editor interface provides functions to
 directly interact with the line editor in use.
 
 ## Functions
-### getLine() -> string
-Returns the current input line.
-
-### getVimRegister(register) -> string
-Returns the text that is at the register.
-
 ### insert(text)
 Inserts text into the line.
-
-### setVimRegister(register, text)
-Sets the vim register at `register` to hold the passed text.
 

--- a/editor.go
+++ b/editor.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"hilbish/util"
-
 	rt "github.com/arnodel/golua/runtime"
 )
 
@@ -11,86 +9,5 @@ import (
 // The hilbish.editor interface provides functions to
 // directly interact with the line editor in use.
 func editorLoader(rtm *rt.Runtime) *rt.Table {
-	exports := map[string]util.LuaExport{
-		"insert": {editorInsert, 1, false},
-		"setVimRegister": {editorSetRegister, 1, false},
-		"getVimRegister": {editorGetRegister, 2, false},
-		"getLine": {editorGetLine, 0, false},
-	}
-
-	mod := rt.NewTable()
-	util.SetExports(rtm, mod, exports)
-
-	return mod
-}
-
-// #interface editor
-// insert(text)
-// Inserts text into the line.
-func editorInsert(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
-	if err := c.Check1Arg(); err != nil {
-		return nil, err
-	}
-
-	text, err := c.StringArg(0)
-	if err != nil {
-		return nil, err
-	}
-
-	lr.rl.Insert(text)
-
-	return c.Next(), nil
-}
-
-// #interface editor
-// setVimRegister(register, text)
-// Sets the vim register at `register` to hold the passed text.
-// --- @param register string
-// --- @param text string
-func editorSetRegister(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
-	if err := c.Check1Arg(); err != nil {
-		return nil, err
-	}
-
-	register, err := c.StringArg(0)
-	if err != nil {
-		return nil, err
-	}
-
-	text, err := c.StringArg(1)
-	if err != nil {
-		return nil, err
-	}
-
-	lr.rl.SetRegisterBuf(register, []rune(text))
-
-	return c.Next(), nil
-}
-
-// #interface editor
-// getVimRegister(register) -> string
-// Returns the text that is at the register.
-// --- @param register string
-func editorGetRegister(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
-	if err := c.Check1Arg(); err != nil {
-		return nil, err
-	}
-
-	register, err := c.StringArg(0)
-	if err != nil {
-		return nil, err
-	}
-
-	buf := lr.rl.GetFromRegister(register)
-
-	return c.PushingNext1(t.Runtime, rt.StringValue(string(buf))), nil
-}
-
-// #interface editor
-// getLine() -> string
-// Returns the current input line.
-func editorGetLine(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
-	buf := lr.rl.GetLine()
-
-	return c.PushingNext1(t.Runtime, rt.StringValue(string(buf))), nil
+	return lr.rl.SetupLua(rtm)
 }

--- a/emmyLuaDocs/hilbish.lua
+++ b/emmyLuaDocs/hilbish.lua
@@ -2,6 +2,9 @@
 
 local hilbish = {}
 
+--- Inserts text into the line.
+function hilbish.editor.insert(text) end
+
 --- This is an alias (ha) for the `hilbish.alias` function.
 --- @param alias string
 --- @param cmd string
@@ -29,21 +32,6 @@ function hilbish.completions.call(name, query, ctx, fields) end
 --- @param line string
 --- @param pos string
 function hilbish.completions.handler(line, pos) end
-
---- Returns the current input line.
-function hilbish.editor.getLine() end
-
---- Returns the text that is at the register.
---- @param register string
-function hilbish.editor.getVimRegister(register) end
-
---- Inserts text into the line.
-function hilbish.editor.insert(text) end
-
---- Sets the vim register at `register` to hold the passed text.
---- @param register string
---- @param text string
-function hilbish.editor.setVimRegister(register, text) end
 
 --- Sets an alias of `cmd` to `orig`
 --- @param cmd string

--- a/readline/lua-api.go
+++ b/readline/lua-api.go
@@ -1,0 +1,37 @@
+package readline
+
+import (
+	"hilbish/util"
+
+	rt "github.com/arnodel/golua/runtime"
+)
+
+func (rl *Instance) SetupLua(rtm *rt.Runtime) *rt.Table {
+	exports := map[string]util.LuaExport{
+		"insert": {rl.editorInsert, 1, false},
+	}
+
+	mod := rt.NewTable()
+	util.SetExports(rtm, mod, exports)
+
+	return mod
+}
+
+// #interface editor
+// insert(text)
+// Inserts text into the line.
+func (rl *Instance) editorInsert(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
+	if err := c.Check1Arg(); err != nil {
+		return nil, err
+	}
+
+	text, err := c.StringArg(0)
+	if err != nil {
+		return nil, err
+	}
+
+	rl.Insert(text)
+
+	return c.Next(), nil
+}
+


### PR DESCRIPTION
this will make it so i dont have to export random functions from readline to hilbish so that i can use them to make the lua functions. it also makes updating to upstream easier (when/if we do)

---
- [x] I have reviewed CONTRIBUTING.md.
- [x] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [ ] I have documented changes and additions in the CHANGELOG.md.
---
