### PR TITLE
feat: Cat implementation now uses chunk reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 🎀 Changelog
 
 ## Unreleased
+### Fixed
+- `cat` command no longer prints extra newline at end of each file
+
 ### Added
 - `cat` command now reads files in chunks, allowing for reading large files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 🎀 Changelog
 
+## Unreleased
+### Added
+- `cat` command now reads files in chunks, allowing for reading large files
+
 ## [2.2.2] - 2024-04-16
 ### Fixed
 - Line refresh fixes (less flicker)

--- a/nature/commands/cat.lua
+++ b/nature/commands/cat.lua
@@ -9,7 +9,7 @@ commander.register('cat', function(args, sinks)
 usage: cat [file]...]]
 	end
 
-	local chunk_size = 2^13 -- 8K buffer size
+	local chunkSize = 2^13 -- 8K buffer size
 
 	for _, fName in ipairs(args) do
 		local f = io.open(fName)
@@ -20,11 +20,10 @@ usage: cat [file]...]]
 		end
 
 		while true do
-			local block = f:read(chunk_size)
+			local block = f:read(chunkSize)
 			if not block then break end
 			sinks.out:write(block)
 		end
-		sinks.out:writeln("")
 		::continue::
 	end
 	io.flush()

--- a/nature/commands/cat.lua
+++ b/nature/commands/cat.lua
@@ -9,6 +9,8 @@ commander.register('cat', function(args, sinks)
 usage: cat [file]...]]
 	end
 
+	local chunk_size = 2^13 -- 8K buffer size
+
 	for _, fName in ipairs(args) do
 		local f = io.open(fName)
 		if f == nil then
@@ -17,7 +19,12 @@ usage: cat [file]...]]
 			goto continue
 		end
 
-		sinks.out:writeln(f:read '*a')
+		while true do
+			local block = f:read(chunk_size)
+			if not block then break end
+			sinks.out:write(block)
+		end
+		sinks.out:writeln("")
 		::continue::
 	end
 	io.flush()


### PR DESCRIPTION
This updates the `cat` command to use a simple form of chunk reading to read files, thus allowing for reading large files without running out of memory.

This should close out #283.

---
- [X] I have reviewed CONTRIBUTING.md.
- [X] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [X] I have documented changes and additions in the CHANGELOG.md.
---
