### PR TITLE
fix: multiline input should have newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ hilbish.run('wc -l', {
 
 ### Fixed
 - Fix ansi attributes causing issues with text when cut off in greenhouse
+- Fix multiline behavior
 
 ## [2.2.3] - 2024-04-27
 ### Fixed

--- a/api.go
+++ b/api.go
@@ -397,7 +397,8 @@ user ~ ∆ echo "hey
 so then you get 
 user ~ ∆ echo "hey
 --> ...!"
-hey ...!
+hey
+...!
 ]]--
 hilbish.multiprompt '-->'
 #example

--- a/exec.go
+++ b/exec.go
@@ -136,7 +136,7 @@ func runInput(input string, priv bool) {
 	}
 
 	if cont {
-		input, err = reprompt(input)
+		input, err = reprompt(input + "\n")
 		if err == nil {
 			goto rerun
 		} else if err == io.EOF {


### PR DESCRIPTION
---
- [x] I have reviewed CONTRIBUTING.md.
- [x] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] I have documented changes and additions in the CHANGELOG.md.
---

When multiline is needed, a newline should be added to the input, much like what other shell would do.

Before newline addition:

```sh
& echo "abc
> def"
abcdef
```

After newline addition:

```sh
& echo "abc
> def"
abc
def
```
However, there's `runLuaRunner(...)` call in exec.go:126 I didn't test for, might be breaking.