### PR TITLE
fix: hilbish.sink.readAll() function now reads data that doesn't end in a newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Skip over file and prevent panic if info cannot be retrieved during file completion (due to permission error or anything else)
 - Apply environment variables properly after 2.3 shell interpreter changes
+- hilbish.sink.readAll() function now reads data that doesn't end in a newline
 
 ## [2.3.3] - 2024-11-04
 ### Fixed

--- a/util/sink.go
+++ b/util/sink.go
@@ -99,6 +99,8 @@ func luaSinkReadAll(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		line, err := s.Rw.ReadString('\n')
 		if err != nil {
 			if err == io.EOF {
+    			// We still want to add the data we read
+        		lines = append(lines, line)
 				break
 			}
 


### PR DESCRIPTION
This fixes most instances of `hilbish.run(some_command, false)` failing when some_command returns a string without a newline, according to #344. However, echo and printf still don't work properly.

For reasons I cannot figure out, when those commands are run, the sink's reader doesn't receive any data at all, so hilbish.sink.readAll() obviously outputs nothing.

---
- [X] I have reviewed CONTRIBUTING.md.
- [X] My commits and title use the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [X] I have documented changes and additions in the CHANGELOG.md.
---
