### PR TITLE
refactor: change job handling to be runner agnostic

### DIFF
--- a/defs/hilbish.jobs.json
+++ b/defs/hilbish.jobs.json
@@ -50,6 +50,22 @@
 					"isType": false
 				},
 				{
+					"name": "suspended",
+					"description": [
+						"Whether",
+						"the",
+						"job",
+						"is",
+						"suspended",
+						"(e.g.",
+						"via",
+						"Ctrl+Z)."
+					],
+					"isInterface": false,
+					"isMember": false,
+					"isType": false
+				},
+				{
 					"name": "id",
 					"description": [
 						"The",
@@ -71,7 +87,15 @@
 					"description": [
 						"The",
 						"Process",
-						"ID"
+						"ID,",
+						"or",
+						"nil",
+						"for",
+						"jobs",
+						"that",
+						"aren't",
+						"OS",
+						"processes."
 					],
 					"isInterface": false,
 					"isMember": false,
@@ -101,15 +125,13 @@
 						"of",
 						"the",
 						"job.",
-						"This",
-						"just",
-						"means",
-						"the",
-						"normal",
-						"logs",
-						"of",
-						"the",
-						"process."
+						"Nil",
+						"for",
+						"jobs",
+						"that",
+						"aren't",
+						"OS",
+						"processes."
 					],
 					"isInterface": false,
 					"isMember": false,
@@ -124,15 +146,14 @@
 						"stream",
 						"of",
 						"the",
-						"process.",
-						"This",
-						"(usually)",
-						"includes",
-						"error",
-						"messages",
-						"of",
-						"the",
-						"job."
+						"job.",
+						"Nil",
+						"for",
+						"jobs",
+						"that",
+						"aren't",
+						"OS",
+						"processes."
 					],
 					"isInterface": false,
 					"isMember": false,
@@ -176,6 +197,20 @@
 						"startIdx": 0
 					},
 					{
+						"id": "suspended",
+						"fields": [
+							"Whether",
+							"the",
+							"job",
+							"is",
+							"suspended",
+							"(e.g.",
+							"via",
+							"Ctrl+Z)."
+						],
+						"startIdx": 0
+					},
+					{
 						"id": "id",
 						"fields": [
 							"The",
@@ -195,7 +230,15 @@
 						"fields": [
 							"The",
 							"Process",
-							"ID"
+							"ID,",
+							"or",
+							"nil",
+							"for",
+							"jobs",
+							"that",
+							"aren't",
+							"OS",
+							"processes."
 						],
 						"startIdx": 0
 					},
@@ -221,15 +264,13 @@
 							"of",
 							"the",
 							"job.",
-							"This",
-							"just",
-							"means",
-							"the",
-							"normal",
-							"logs",
-							"of",
-							"the",
-							"process."
+							"Nil",
+							"for",
+							"jobs",
+							"that",
+							"aren't",
+							"OS",
+							"processes."
 						],
 						"startIdx": 0
 					},
@@ -242,15 +283,14 @@
 							"stream",
 							"of",
 							"the",
-							"process.",
-							"This",
-							"(usually)",
-							"includes",
-							"error",
-							"messages",
-							"of",
-							"the",
-							"job."
+							"job.",
+							"Nil",
+							"for",
+							"jobs",
+							"that",
+							"aren't",
+							"OS",
+							"processes."
 						],
 						"startIdx": 0
 					}
@@ -269,14 +309,16 @@
 		{
 			"name": "jobs.add",
 			"description": [
-				"Creates a new job. This function does not run the job. This function is intended to be",
-				"used by runners, but can also be used to create jobs via Lua. Commanders cannot be ran as jobs.",
+				"Creates a new job but does not run it. The job kind is decided by `opts`:",
+				"a process job is created from `args`/`path` (with optional `env`, `dir`",
+				"and `sinks`), while a lua/code job is created by supplying `run` (and",
+				"optionally `suspend`/`resume`) functions.",
 				"",
 				""
 			],
 			"parent": "hilbish",
 			"interfaces": "jobs",
-			"signature": "add(cmdstr, args, execPath)",
+			"signature": "add(cmdstr, opts) -\u003e @Job",
 			"goFuncName": "luaaddjob",
 			"isInterface": true,
 			"isMember": false,
@@ -298,40 +340,11 @@
 					]
 				},
 				{
-					"Name": "args",
+					"Name": "opts",
 					"Type": "table",
 					"Doc": [
-						"Arguments",
-						"for",
-						"the",
-						"commands.",
-						"Has",
-						"to",
-						"include",
-						"the",
-						"name",
-						"of",
-						"the",
-						"command."
-					]
-				},
-				{
-					"Name": "execPath",
-					"Type": "string",
-					"Doc": [
-						"Binary",
-						"to",
-						"use",
-						"to",
-						"run",
-						"the",
-						"command.",
-						"Needs",
-						"to",
-						"be",
-						"an",
-						"absolute",
-						"path."
+						"Job",
+						"options."
 					]
 				}
 			],
@@ -340,9 +353,20 @@
 					{
 						"id": "",
 						"fields": [
-							"hilbish.jobs.add('go build', {'go', 'build'}, '/usr/bin/go')"
+							"-- a process job",
+							"hilbish.jobs.add('go build', {",
+							"\targs = {'go', 'build'},",
+							"\tpath = '/usr/bin/go',",
+							"})",
+							"",
+							"-- a lua/code job (suspendable if the runner can handle it)",
+							"hilbish.jobs.add('my task', {",
+							"\trun = function(job) --[[ ... ]] return 0 end,",
+							"\tsuspend = function(job) --[[ pause ]] end,",
+							"\tresume = function(job, fg) --[[ resume ]] end,",
+							"})"
 						],
-						"startIdx": 8
+						"startIdx": 9
 					}
 				],
 				"interface": [
@@ -367,44 +391,14 @@
 							"the",
 							"job"
 						],
-						"startIdx": 4
+						"startIdx": 6
 					},
 					{
-						"id": "args",
+						"id": "opts",
 						"fields": [
 							"table",
-							"Arguments",
-							"for",
-							"the",
-							"commands.",
-							"Has",
-							"to",
-							"include",
-							"the",
-							"name",
-							"of",
-							"the",
-							"command."
-						],
-						"startIdx": 0
-					},
-					{
-						"id": "execPath",
-						"fields": [
-							"string",
-							"Binary",
-							"to",
-							"use",
-							"to",
-							"run",
-							"the",
-							"command.",
-							"Needs",
-							"to",
-							"be",
-							"an",
-							"absolute",
-							"path."
+							"Job",
+							"options."
 						],
 						"startIdx": 0
 					}
@@ -418,7 +412,7 @@
 			],
 			"parent": "hilbish",
 			"interfaces": "jobs",
-			"signature": "all() -\u003e table[@Job]",
+			"signature": "all() -\u003e table\u003c@Job\u003e",
 			"goFuncName": "luaalljobs",
 			"isInterface": true,
 			"isMember": false,
@@ -433,7 +427,7 @@
 				],
 				"returns": [
 					{
-						"id": "table[Job]",
+						"id": "table\u003cJob\u003e",
 						"fields": [],
 						"startIdx": 3
 					}
@@ -443,7 +437,7 @@
 		{
 			"name": "jobs.background",
 			"description": [
-				"Puts a job in the background. This acts the same as initially running a job."
+				"Resumes a suspended job in the background."
 			],
 			"parent": "hilbish",
 			"interfaces": "jobs",
@@ -510,8 +504,8 @@
 		{
 			"name": "jobs.foreground",
 			"description": [
-				"Puts a job in the foreground. This will cause it to run like it was",
-				"executed normally and wait for it to complete."
+				"Resumes a suspended or backgrounded job in the foreground. This will cause",
+				"it to run like it was executed normally and wait for it to complete."
 			],
 			"parent": "hilbish",
 			"interfaces": "jobs",
@@ -591,11 +585,13 @@
 		{
 			"name": "jobs.start",
 			"description": [
-				"Starts running the job."
+				"Starts running the job. If opts.background is true, runs in background.",
+				"Otherwise runs in foreground and blocks until completion or suspension.",
+				"Returns the exit code."
 			],
 			"parent": "hilbish",
 			"interfaces": "jobs",
-			"signature": "start()",
+			"signature": "start(opts)",
 			"goFuncName": "luastartjob",
 			"isInterface": true,
 			"isMember": true,

--- a/docs/api/hilbish.jobs.md
+++ b/docs/api/hilbish.jobs.md
@@ -17,8 +17,8 @@ interactive usage or with the functions defined below for use in external runner
 
 ## Functions
 
-- [`hilbish.jobs.add(cmdstr, args, execPath)`](#jobs.add): Creates a new job. This function does not run the job. This function is intended to be
-- [`hilbish.jobs.all() -> table[@Job]`](#jobs.all): Returns a table of all job objects.
+- [`hilbish.jobs.add(cmdstr, opts) -> @Job`](#jobs.add): Creates a new job but does not run it. The job kind is decided by `opts`:
+- [`hilbish.jobs.all() -> table<@Job>`](#jobs.all): Returns a table of all job objects.
 - [`hilbish.jobs.disown(id)`](#jobs.disown): Disowns a job. This simply deletes it from the list of jobs without stopping it.
 - [`hilbish.jobs.get(id) -> @Job`](#jobs.get): Get a job object via its ID.
 - [`hilbish.jobs.last() -> @Job`](#jobs.last): Returns the last added job to the table.
@@ -28,26 +28,36 @@ interactive usage or with the functions defined below for use in external runner
 
 #### jobs.add
 
-hilbish.jobs.add(cmdstr, args, execPath)
+hilbish.jobs.add(cmdstr, opts) -> @Job
 
-Creates a new job. This function does not run the job. This function is intended to be  
-used by runners, but can also be used to create jobs via Lua. Commanders cannot be ran as jobs.  
+Creates a new job but does not run it. The job kind is decided by `opts`:  
+a process job is created from `args`/`path` (with optional `env`, `dir`  
+and `sinks`), while a lua/code job is created by supplying `run` (and  
+optionally `suspend`/`resume`) functions.  
 
 #### Parameters
 
 `string` _cmdstr_  
 String that a user would write for the job
 
-`table` _args_  
-Arguments for the commands. Has to include the name of the command.
-
-`string` _execPath_  
-Binary to use to run the command. Needs to be an absolute path.
+`table` _opts_  
+Job options.
 
 #### Example
 
 ```lua
-hilbish.jobs.add('go build', {'go', 'build'}, '/usr/bin/go')
+-- a process job
+hilbish.jobs.add('go build', {
+	args = {'go', 'build'},
+	path = '/usr/bin/go',
+})
+
+-- a lua/code job (suspendable if the runner can handle it)
+hilbish.jobs.add('my task', {
+	run = function(job) --[[ ... ]] return 0 end,
+	suspend = function(job) --[[ pause ]] end,
+	resume = function(job, fg) --[[ resume ]] end,
+})
 ```
 
 
@@ -55,7 +65,7 @@ hilbish.jobs.add('go build', {'go', 'build'}, '/usr/bin/go')
 
 #### jobs.all
 
-hilbish.jobs.all() -> table[@Job]
+hilbish.jobs.all() -> table<@Job>
 
 Returns a table of all job objects.  
 
@@ -129,27 +139,30 @@ The Job type describes a Hilbish job.
 
 - `cmd`: The user entered command string for the job.
 - `running`: Whether the job is running or not.
+- `suspended`: Whether the job is suspended (e.g. via Ctrl+Z).
 - `id`: The ID of the job in the job table
-- `pid`: The Process ID
+- `pid`: The Process ID, or nil for jobs that aren't OS processes.
 - `exitCode`: The last exit code of the job.
-- `stdout`: The standard output of the job. This just means the normal logs of the process.
-- `stderr`: The standard error stream of the process. This (usually) includes error messages of the job.
+- `stdout`: The standard output of the job. Nil for jobs that aren't OS processes.
+- `stderr`: The standard error stream of the job. Nil for jobs that aren't OS processes.
 
 
 ### Methods
 
 #### background()
 
-Puts a job in the background. This acts the same as initially running a job.
+Resumes a suspended job in the background.
 
 #### foreground()
 
-Puts a job in the foreground. This will cause it to run like it was
-executed normally and wait for it to complete.
+Resumes a suspended or backgrounded job in the foreground. This will cause
+it to run like it was executed normally and wait for it to complete.
 
-#### start()
+#### start(opts)
 
-Starts running the job.
+Starts running the job. If opts.background is true, runs in background.
+Otherwise runs in foreground and blocks until completion or suspension.
+Returns the exit code.
 
 #### stop()
 

--- a/golibs/snail/snail.go
+++ b/golibs/snail/snail.go
@@ -1,16 +1,12 @@
 package snail
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"os/signal"
-	"runtime"
 	"strings"
-	"time"
 
 	"github.com/sammy-ette/hilbish/moonlight"
 	"github.com/sammy-ette/hilbish/util"
@@ -27,6 +23,14 @@ import (
 type Snail struct {
 	runner  *interp.Runner
 	runtime *moonlight.Runtime
+
+	// interp.ExecHandlers stacks middleware and our handler never calls next,
+	// so only register it once otherwise an old stale one keeps running
+	handlerReady     bool
+	aliasesListFn    moonlight.Value
+	aliasesResolveFn moonlight.Value
+	runJobFn         moonlight.Value
+	bg               bool
 }
 
 func New(mlr *moonlight.Runtime) *Snail {
@@ -70,215 +74,13 @@ func (s *Snail) Run(cmd string, strms *util.Streams) (bool, io.Writer, io.Writer
 	interp.StdIO(strms.Stdin, strms.Stdout, strms.Stderr)(s.runner)
 	interp.Env(expand.ListEnviron(append(os.Environ(), "PATH="+os.Getenv("PATH"))...))(s.runner)
 
-	buf := new(bytes.Buffer)
-	//printer := syntax.NewPrinter()
-
-	aliasesMod := s.runtime.MustDoString("return hilbish.aliases").AsTable()
-	aliasesListFn := aliasesMod.Get(moonlight.StringValue("list"))
-	aliasesResolveFn := aliasesMod.Get(moonlight.StringValue("resolve"))
+	s.ensureHandler()
 
 	var bg bool
 	for _, stmt := range file.Stmts {
-		bg = false
-		if stmt.Background {
-			bg = true
-			//printer.Print(buf, stmt.Cmd)
+		bg = stmt.Background
+		s.bg = stmt.Background
 
-			//stmtStr := buf.String()
-			buf.Reset()
-			//jobs.add(stmtStr, []string{}, "")
-		}
-
-		execHandler := func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
-			return func(ctx context.Context, args []string) error {
-				argstring := strings.Join(args, " ")
-				// i dont really like this but it works
-				aliases := make(map[string]string)
-				aliasesLua, err := s.runtime.Call1(aliasesListFn)
-				if err != nil {
-					return err
-				}
-				moonlight.ForEach(moonlight.ToTable(aliasesLua), func(k, v moonlight.Value) {
-					aliases[k.AsString()] = v.AsString()
-				})
-				if aliases[args[0]] != "" {
-					for i, arg := range args {
-						if strings.Contains(arg, " ") {
-							args[i] = fmt.Sprintf("\"%s\"", arg)
-						}
-					}
-					argstring = strings.Join(args, " ")
-
-					// If alias was found, use command alias
-					resolved, err := s.runtime.Call1(aliasesResolveFn, moonlight.StringValue(argstring))
-					if err != nil {
-						return err
-					}
-					argstring = resolved.AsString()
-
-					args, err = shell.Fields(argstring, nil)
-					if err != nil {
-						return err
-					}
-				}
-
-				// If command is defined in Lua then run it
-				luacmdArgs := moonlight.NewTable()
-				for i, str := range args[1:] {
-					luacmdArgs.Set(moonlight.IntValue(int64(i+1)), moonlight.StringValue(str))
-				}
-
-				hc := interp.HandlerCtx(ctx)
-
-				cmds := make(map[string]*moonlight.Closure)
-				luaCmds := moonlight.ToTable(s.runtime.MustDoString("local commander = require 'commander'; return commander.registry()"))
-				moonlight.ForEach(luaCmds, func(k, v moonlight.Value) {
-					cmds[k.AsString()] = v.AsTable().Get(moonlight.StringValue("exec")).AsClosure()
-				})
-				if cmd := cmds[args[0]]; cmd != nil {
-					stdin := util.NewSinkInput(s.runtime, hc.Stdin)
-					stdout := util.NewSinkOutput(s.runtime, hc.Stdout)
-					stderr := util.NewSinkOutput(s.runtime, hc.Stderr)
-
-					sinks := moonlight.NewTable()
-					sinks.Set(moonlight.StringValue("in"), moonlight.UserDataValue(stdin.UserData))
-					sinks.Set(moonlight.StringValue("input"), moonlight.UserDataValue(stdin.UserData))
-					sinks.Set(moonlight.StringValue("out"), moonlight.UserDataValue(stdout.UserData))
-					sinks.Set(moonlight.StringValue("err"), moonlight.UserDataValue(stderr.UserData))
-
-					t := moonlight.NewThread(s.runtime)
-					sig := make(chan os.Signal, 1)
-					exit := make(chan bool, 1)
-					done := make(chan struct{})
-
-					luaexitcode := moonlight.IntValue(63)
-					var err error
-
-					signal.Notify(sig, os.Interrupt)
-					go func() {
-						select {
-						case <-sig:
-							t.Kill()
-						case <-done: // branch allows the goroutine to go away
-						}
-					}()
-
-					go func() {
-						luaexitcode, err = t.Call1(moonlight.FunctionValue(cmd), moonlight.TableValue(luacmdArgs), moonlight.TableValue(sinks))
-						exit <- true
-					}()
-
-					<-exit
-					close(done)
-					signal.Stop(sig)
-					if err != nil {
-						fmt.Fprintln(os.Stderr, "Error in command:\n"+err.Error())
-						return interp.NewExitStatus(1)
-					}
-
-					var exitcode uint8
-
-					if code, ok := luaexitcode.TryInt(); ok {
-						exitcode = uint8(code)
-					} else if luaexitcode != moonlight.NilValue {
-						commanderMod := s.runtime.MustDoString("return require 'commander'").AsTable()
-						deregister := commanderMod.Get(moonlight.StringValue("deregister"))
-						s.runtime.Call1(deregister, moonlight.StringValue(args[0]))
-						fmt.Fprintf(os.Stderr, "Commander did not return number for exit code. %s, you're fired.\n", args[0])
-					}
-
-					return interp.NewExitStatus(exitcode)
-				}
-
-				path, err := util.LookPath(args[0])
-				if err == util.ErrNotExec {
-					return util.ExecError{
-						Typ:   "not-executable",
-						Cmd:   args[0],
-						Code:  126,
-						Colon: true,
-						Err:   util.ErrNotExec,
-					}
-				} else if err != nil {
-					return util.ExecError{
-						Typ:  "not-found",
-						Cmd:  args[0],
-						Code: 127,
-						Err:  util.ErrNotFound,
-					}
-				}
-
-				killTimeout := 2 * time.Second
-				// from here is basically copy-paste of the default exec handler from
-				// sh/interp but with our job handling
-
-				env := hc.Env
-				envList := os.Environ()
-				env.Each(func(name string, vr expand.Variable) bool {
-					if name == "PATH" {
-						return true
-					}
-					if vr.Exported && vr.Kind == expand.String {
-						envList = append(envList, name+"="+vr.String())
-					}
-					return true
-				})
-
-				cmd := exec.Cmd{
-					Path:   path,
-					Args:   args,
-					Env:    envList,
-					Dir:    hc.Dir,
-					Stdin:  hc.Stdin,
-					Stdout: hc.Stdout,
-					Stderr: hc.Stderr,
-				}
-
-				//var j *job
-				if bg {
-					/*
-						j = jobs.getLatest()
-						j.setHandle(&cmd)
-						err = j.start()
-					*/
-				} else {
-					err = cmd.Start()
-				}
-
-				if err == nil {
-					if done := ctx.Done(); done != nil {
-						go func() {
-							<-done
-
-							if killTimeout <= 0 || runtime.GOOS == "windows" {
-								cmd.Process.Signal(os.Kill)
-								return
-							}
-
-							// TODO: don't temporarily leak this goroutine
-							// if the program stops itself with the
-							// interrupt.
-							go func() {
-								time.Sleep(killTimeout)
-								cmd.Process.Signal(os.Kill)
-							}()
-							cmd.Process.Signal(os.Interrupt)
-						}()
-					}
-
-					err = cmd.Wait()
-				}
-
-				exit := util.HandleExecErr(err)
-
-				if bg {
-					//j.exitCode = int(exit)
-					//j.finish()
-				}
-				return interp.NewExitStatus(exit)
-			}
-		}
-		interp.ExecHandlers(execHandler)(s.runner)
 		err = s.runner.Run(context.TODO(), stmt)
 		if err != nil {
 			return bg, strms.Stdout, strms.Stderr, err
@@ -286,4 +88,195 @@ func (s *Snail) Run(cmd string, strms *util.Streams) (bool, io.Writer, io.Writer
 	}
 
 	return bg, strms.Stdout, strms.Stderr, nil
+}
+
+func (s *Snail) ensureHandler() {
+	if s.handlerReady {
+		return
+	}
+	s.handlerReady = true
+
+	aliasesMod := s.runtime.MustDoString("return hilbish.aliases").AsTable()
+	s.aliasesListFn = aliasesMod.Get(moonlight.StringValue("list"))
+	s.aliasesResolveFn = aliasesMod.Get(moonlight.StringValue("resolve"))
+
+	s.runJobFn = s.runtime.MustDoString(`
+		return function(cmdstr, opts, background)
+			local j = hilbish.jobs.add(cmdstr, opts)
+			return j:start{ background = background }
+		end
+	`)
+
+	execHandler := func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
+		return func(ctx context.Context, args []string) error {
+			argstring := strings.Join(args, " ")
+			// i dont really like this but it works
+			aliases := make(map[string]string)
+			aliasesLua, err := s.runtime.Call1(s.aliasesListFn)
+			if err != nil {
+				return err
+			}
+			moonlight.ForEach(moonlight.ToTable(aliasesLua), func(k, v moonlight.Value) {
+				aliases[k.AsString()] = v.AsString()
+			})
+			if aliases[args[0]] != "" {
+				for i, arg := range args {
+					if strings.Contains(arg, " ") {
+						args[i] = fmt.Sprintf("\"%s\"", arg)
+					}
+				}
+				argstring = strings.Join(args, " ")
+
+				// If alias was found, use command alias
+				resolved, err := s.runtime.Call1(s.aliasesResolveFn, moonlight.StringValue(argstring))
+				if err != nil {
+					return err
+				}
+				argstring = resolved.AsString()
+
+				args, err = shell.Fields(argstring, nil)
+				if err != nil {
+					return err
+				}
+			}
+
+			// If command is defined in Lua then run it
+			luacmdArgs := moonlight.NewTable()
+			for i, str := range args[1:] {
+				luacmdArgs.Set(moonlight.IntValue(int64(i+1)), moonlight.StringValue(str))
+			}
+
+			hc := interp.HandlerCtx(ctx)
+
+			cmds := make(map[string]*moonlight.Closure)
+			luaCmds := moonlight.ToTable(s.runtime.MustDoString("local commander = require 'commander'; return commander.registry()"))
+			moonlight.ForEach(luaCmds, func(k, v moonlight.Value) {
+				cmds[k.AsString()] = v.AsTable().Get(moonlight.StringValue("exec")).AsClosure()
+			})
+			if cmd := cmds[args[0]]; cmd != nil {
+				stdin := util.NewSinkInput(s.runtime, hc.Stdin)
+				stdout := util.NewSinkOutput(s.runtime, hc.Stdout)
+				stderr := util.NewSinkOutput(s.runtime, hc.Stderr)
+
+				sinks := moonlight.NewTable()
+				sinks.Set(moonlight.StringValue("in"), moonlight.UserDataValue(stdin.UserData))
+				sinks.Set(moonlight.StringValue("input"), moonlight.UserDataValue(stdin.UserData))
+				sinks.Set(moonlight.StringValue("out"), moonlight.UserDataValue(stdout.UserData))
+				sinks.Set(moonlight.StringValue("err"), moonlight.UserDataValue(stderr.UserData))
+
+				t := moonlight.NewThread(s.runtime)
+				sig := make(chan os.Signal, 1)
+				exit := make(chan bool, 1)
+				done := make(chan struct{})
+
+				luaexitcode := moonlight.IntValue(63)
+				var err error
+
+				signal.Notify(sig, os.Interrupt)
+				go func() {
+					select {
+					case <-sig:
+						t.Kill()
+					case <-done: // branch allows the goroutine to go away
+					}
+				}()
+
+				go func() {
+					luaexitcode, err = t.Call1(moonlight.FunctionValue(cmd), moonlight.TableValue(luacmdArgs), moonlight.TableValue(sinks))
+					exit <- true
+				}()
+
+				<-exit
+				close(done)
+				signal.Stop(sig)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "Error in command:\n"+err.Error())
+					return interp.NewExitStatus(1)
+				}
+
+				var exitcode uint8
+
+				if code, ok := luaexitcode.TryInt(); ok {
+					exitcode = uint8(code)
+				} else if luaexitcode != moonlight.NilValue {
+					commanderMod := s.runtime.MustDoString("return require 'commander'").AsTable()
+					deregister := commanderMod.Get(moonlight.StringValue("deregister"))
+					s.runtime.Call1(deregister, moonlight.StringValue(args[0]))
+					fmt.Fprintf(os.Stderr, "Commander did not return number for exit code. %s, you're fired.\n", args[0])
+				}
+
+				return interp.NewExitStatus(exitcode)
+			}
+
+			path, err := util.LookPath(args[0])
+			if err == util.ErrNotExec {
+				return util.ExecError{
+					Typ:   "not-executable",
+					Cmd:   args[0],
+					Code:  126,
+					Colon: true,
+					Err:   util.ErrNotExec,
+				}
+			} else if err != nil {
+				return util.ExecError{
+					Typ:  "not-found",
+					Cmd:  args[0],
+					Code: 127,
+					Err:  util.ErrNotFound,
+				}
+			}
+
+			env := hc.Env
+			envList := os.Environ()
+			env.Each(func(name string, vr expand.Variable) bool {
+				if name == "PATH" {
+					return true
+				}
+				if vr.Exported && vr.Kind == expand.String {
+					envList = append(envList, name+"="+vr.String())
+				}
+				return true
+			})
+
+			optsTbl := moonlight.NewTable()
+
+			argsTbl := moonlight.NewTable()
+			for i, a := range args {
+				argsTbl.Set(moonlight.IntValue(int64(i+1)), moonlight.StringValue(a))
+			}
+			optsTbl.Set(moonlight.StringValue("args"), moonlight.TableValue(argsTbl))
+			optsTbl.Set(moonlight.StringValue("path"), moonlight.StringValue(path))
+			optsTbl.Set(moonlight.StringValue("dir"), moonlight.StringValue(hc.Dir))
+
+			envTbl := moonlight.NewTable()
+			for i, e := range envList {
+				envTbl.Set(moonlight.IntValue(int64(i+1)), moonlight.StringValue(e))
+			}
+			optsTbl.Set(moonlight.StringValue("env"), moonlight.TableValue(envTbl))
+
+			sinksTbl := moonlight.NewTable()
+			inSink := util.NewSinkInput(s.runtime, hc.Stdin)
+			outSink := util.NewSinkOutput(s.runtime, hc.Stdout)
+			errSink := util.NewSinkOutput(s.runtime, hc.Stderr)
+			sinksTbl.Set(moonlight.StringValue("in"), moonlight.UserDataValue(inSink.UserData))
+			sinksTbl.Set(moonlight.StringValue("out"), moonlight.UserDataValue(outSink.UserData))
+			sinksTbl.Set(moonlight.StringValue("err"), moonlight.UserDataValue(errSink.UserData))
+			optsTbl.Set(moonlight.StringValue("sinks"), moonlight.TableValue(sinksTbl))
+
+			exitVal, err := s.runtime.Call1(s.runJobFn,
+				moonlight.StringValue(argstring),
+				moonlight.TableValue(optsTbl),
+				moonlight.BoolValue(s.bg),
+			)
+
+			var exit uint8
+			if err != nil {
+				exit = util.HandleExecErr(err)
+			} else if code, ok := exitVal.TryInt(); ok {
+				exit = uint8(code)
+			}
+			return interp.NewExitStatus(exit)
+		}
+	}
+	interp.ExecHandlers(execHandler)(s.runner)
 }

--- a/golibs/snail/snail.go
+++ b/golibs/snail/snail.go
@@ -31,8 +31,11 @@ type Snail struct {
 	aliasesListFn    moonlight.Value
 	aliasesResolveFn moonlight.Value
 	runJobFn         moonlight.Value
-	bg               bool
 }
+
+type snailContextKey int
+
+const backgroundContextKey snailContextKey = iota
 
 func New(mlr *moonlight.Runtime) *Snail {
 	runner, _ := interp.New()
@@ -80,9 +83,14 @@ func (s *Snail) Run(cmd string, strms *util.Streams) (bool, io.Writer, io.Writer
 	var bg bool
 	for _, stmt := range file.Stmts {
 		bg = stmt.Background
-		s.bg = stmt.Background
 
-		err = s.runner.Run(context.TODO(), stmt)
+		// jobs already handle backgrounding so dont let sh interp do it too
+		// pass it through context so the handler knows its background
+		runStmt := *stmt
+		runStmt.Background = false
+		ctx := context.WithValue(context.Background(), backgroundContextKey, bg)
+
+		err = s.runner.Run(ctx, &runStmt)
 		if err != nil {
 			return bg, strms.Stdout, strms.Stderr, err
 		}
@@ -110,6 +118,7 @@ func (s *Snail) ensureHandler() {
 
 	execHandler := func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
 		return func(ctx context.Context, args []string) error {
+			background, _ := ctx.Value(backgroundContextKey).(bool)
 			argstring := strings.Join(args, " ")
 			// i dont really like this but it works
 			aliases := make(map[string]string)
@@ -267,7 +276,7 @@ func (s *Snail) ensureHandler() {
 			exitVal, err := s.runtime.Call1(s.runJobFn,
 				moonlight.StringValue(argstring),
 				moonlight.TableValue(optsTbl),
-				moonlight.BoolValue(s.bg),
+				moonlight.BoolValue(background),
 			)
 
 			var exit uint8

--- a/job.go
+++ b/job.go
@@ -17,80 +17,234 @@ import (
 var jobs *jobHandler
 var jobMetaKey = moonlight.StringValue("hshjob")
 
+type jobType int
+
+const (
+	jobProcess jobType = iota
+	jobLua
+)
+
 // #type
 // #interface jobs
 // #property cmd The user entered command string for the job.
 // #property running Whether the job is running or not.
+// #property suspended Whether the job is suspended (e.g. via Ctrl+Z).
 // #property id The ID of the job in the job table
-// #property pid The Process ID
+// #property pid The Process ID, or nil for jobs that aren't OS processes.
 // #property exitCode The last exit code of the job.
-// #property stdout The standard output of the job. This just means the normal logs of the process.
-// #property stderr The standard error stream of the process. This (usually) includes error messages of the job.
+// #property stdout The standard output of the job. Nil for jobs that aren't OS processes.
+// #property stderr The standard error stream of the job. Nil for jobs that aren't OS processes.
 // The Job type describes a Hilbish job.
 type job struct {
-	mu       sync.RWMutex
-	cmd      string
-	running  bool
-	id       int
-	pid      int
-	exitCode int
-	once     bool
-	args     []string
-	// save path for a few reasons, one being security (lmao) while the other
-	// would just be so itll be the same binary command always (path changes)
-	path   string
-	handle *exec.Cmd
-	cmdout io.Writer
-	cmderr io.Writer
-	stdout *bytes.Buffer
-	stderr *bytes.Buffer
-	ud     *moonlight.UserData
+	mu        sync.RWMutex
+	cmd       string
+	typ       jobType
+	running   bool
+	suspended bool
+	id        int
+	pid       int
+	exitCode  int
+	ud        *moonlight.UserData
+
+	// process jobs
+	path    string
+	args    []string
+	env     []string
+	dir     string
+	stdin   io.Reader
+	cmdout  io.Writer
+	cmderr  io.Writer
+	capture bool
+	handle  *exec.Cmd
+	stdout  *bytes.Buffer
+	stderr  *bytes.Buffer
+
+	// lua jobs. how it runs/suspends/resumes is all up to the runner
+	runFn     moonlight.Value
+	suspendFn moonlight.Value
+	resumeFn  moonlight.Value
+	done      chan int
 }
 
-func (j *job) start() error {
-	j.mu.Lock()
+// run starts the job. foreground blocks until it exits or is suspended,
+// background reaps it in the back.
+func (j *job) run(foreground bool) (int, error) {
+	if j.typ == jobLua {
+		return j.runLua(foreground), nil
+	}
 
-	if j.handle == nil || j.once {
-		// cmd cant be reused so make a new one
-		cmd := exec.Cmd{
-			Path: j.path,
-			Args: j.args,
-		}
-		j.setHandle(&cmd)
+	if err := j.startProc(); err != nil {
+		return int(util.HandleExecErr(err)), nil
+	}
+	if foreground {
+		return j.procForeground()
+	}
+	go j.procWait()
+	return 0, nil
+}
+
+func (j *job) startProc() error {
+	cmd := &exec.Cmd{
+		Path:  j.path,
+		Args:  j.args,
+		Env:   j.env,
+		Dir:   j.dir,
+		Stdin: j.stdin,
 	}
 	// bgProcAttr is defined in job_<os>.go, it holds a procattr struct
 	// in a simple explanation, it makes signals from hilbish (like sigint)
 	// not go to it (child process)
-	j.handle.SysProcAttr = bgProcAttr
-	// reset output buffers
-	j.stdout.Reset()
-	j.stderr.Reset()
-	// make cmd write to both standard output and output buffers for lua access
-	j.handle.Stdout = io.MultiWriter(j.cmdout, j.stdout)
-	j.handle.Stderr = io.MultiWriter(j.cmderr, j.stderr)
+	cmd.SysProcAttr = bgProcAttr
+	if j.capture {
+		j.stdout.Reset()
+		j.stderr.Reset()
+		cmd.Stdout = io.MultiWriter(j.cmdout, j.stdout)
+		cmd.Stderr = io.MultiWriter(j.cmderr, j.stderr)
+	} else {
+		cmd.Stdout = j.cmdout
+		cmd.Stderr = j.cmderr
+	}
+	j.handle = cmd
 
-	if !j.once {
-		j.once = true
+	err := cmd.Start()
+	if cmd.Process != nil {
+		j.pid = cmd.Process.Pid
 	}
 
-	err := j.handle.Start()
-	if proc := j.handle.Process; proc != nil {
-		j.pid = proc.Pid
-	}
+	j.mu.Lock()
 	j.running = true
-
+	j.suspended = false
 	j.mu.Unlock()
 
-	hooks.Emit("job.start", moonlight.UserDataValue(j.ud))
-
+	j.emitIfRegistered("job.start")
 	return err
 }
 
+func (j *job) runLua(foreground bool) int {
+	j.done = make(chan int, 1)
+
+	j.mu.Lock()
+	j.running = true
+	j.suspended = false
+	j.mu.Unlock()
+
+	j.emitIfRegistered("job.start")
+
+	go func() {
+		t := moonlight.NewThread(l)
+		ret, err := t.Call1(j.runFn, moonlight.UserDataValue(j.ud))
+		code := 0
+		if err == nil {
+			if c, ok := ret.TryInt(); ok {
+				code = int(c)
+			}
+		}
+		j.done <- code
+	}()
+
+	if foreground {
+		return j.awaitLua()
+	}
+	go j.awaitLua()
+	return 0
+}
+
+func (j *job) awaitLua() int {
+	code := <-j.done
+
+	j.mu.Lock()
+	suspended := j.suspended
+	if !suspended {
+		j.running = false
+	}
+	j.mu.Unlock()
+
+	if !suspended {
+		j.finish()
+	}
+	return code
+}
+
+// suspend pauses the job. for a process this is sigstop, for a lua job its
+// whatever the runner does in its suspend function
+func (j *job) suspend() error {
+	if j.typ == jobLua {
+		if j.suspendFn == moonlight.NilValue {
+			return errors.New("job is not suspendable")
+		}
+		j.mu.Lock()
+		j.suspended = true
+		j.mu.Unlock()
+		_, err := l.Call1(j.suspendFn, moonlight.UserDataValue(j.ud))
+		return err
+	}
+	return j.procSuspend()
+}
+
+func (j *job) foreground() error {
+	if j.typ == jobLua {
+		return j.resumeLua(true)
+	}
+
+	j.mu.Lock()
+	j.running = true
+	j.suspended = false
+	j.mu.Unlock()
+
+	if err := j.procContinue(); err != nil {
+		return err
+	}
+	_, err := j.procForeground()
+	return err
+}
+
+func (j *job) background() error {
+	if j.typ == jobLua {
+		return j.resumeLua(false)
+	}
+
+	j.mu.Lock()
+	j.running = true
+	j.suspended = false
+	j.mu.Unlock()
+
+	if err := j.procContinue(); err != nil {
+		return err
+	}
+	go j.procWait()
+	return nil
+}
+
+func (j *job) resumeLua(foreground bool) error {
+	if j.resumeFn == moonlight.NilValue {
+		return errors.New("job is not resumable")
+	}
+	j.mu.Lock()
+	j.suspended = false
+	j.running = true
+	j.mu.Unlock()
+
+	_, err := l.Call1(j.resumeFn, moonlight.UserDataValue(j.ud), moonlight.BoolValue(foreground))
+	if err != nil {
+		return err
+	}
+	if foreground {
+		j.awaitLua()
+	} else {
+		go j.awaitLua()
+	}
+	return nil
+}
+
 func (j *job) stop() {
-	// finish will be called in exec handle
-	proc := j.getProc()
-	if proc != nil {
-		proc.Kill()
+	if j.typ == jobLua {
+		if j.suspendFn != moonlight.NilValue {
+			l.Call1(j.suspendFn, moonlight.UserDataValue(j.ud))
+		}
+		return
+	}
+	if j.handle != nil && j.handle.Process != nil {
+		j.handle.Process.Kill()
 	}
 }
 
@@ -99,47 +253,26 @@ func (j *job) finish() {
 	j.running = false
 	j.mu.Unlock()
 
-	hooks.Emit("job.done", moonlight.UserDataValue(j.ud))
+	j.emitIfRegistered("job.done")
 }
 
-func (j *job) wait() {
+// only fire hooks for jobs actually in the table
+func (j *job) emitIfRegistered(event string) {
 	j.mu.RLock()
-	handle := j.handle
+	registered := j.id != 0
 	j.mu.RUnlock()
 
-	if handle != nil {
-		handle.Wait()
+	if registered {
+		hooks.Emit(event, moonlight.UserDataValue(j.ud))
 	}
-}
-
-// setHandle sets the exec.Cmd for the job. Callers must hold j.mu.
-func (j *job) setHandle(handle *exec.Cmd) {
-	j.handle = handle
-	j.args = handle.Args
-	j.path = handle.Path
-	if handle.Stdout != nil {
-		j.cmdout = handle.Stdout
-	}
-	if handle.Stderr != nil {
-		j.cmderr = handle.Stderr
-	}
-}
-
-func (j *job) getProc() *os.Process {
-	j.mu.RLock()
-	defer j.mu.RUnlock()
-
-	if j.handle != nil {
-		return j.handle.Process
-	}
-
-	return nil
 }
 
 // #interface jobs
 // #member
-// start()
-// Starts running the job.
+// start(opts)
+// Starts running the job. If opts.background is true, runs in background.
+// Otherwise runs in foreground and blocks until completion or suspension.
+// Returns the exit code.
 func luaStartJob(mlr *moonlight.Runtime) error {
 	if err := mlr.Check1Arg(); err != nil {
 		return err
@@ -150,22 +283,30 @@ func luaStartJob(mlr *moonlight.Runtime) error {
 		return err
 	}
 
+	background := false
+	if etc := mlr.Etc(); len(etc) > 0 {
+		if opts, ok := moonlight.TryTable(etc[0]); ok {
+			if bg, ok := opts.Get(moonlight.StringValue("background")).TryBool(); ok {
+				background = bg
+			}
+		}
+	}
+
 	j.mu.RLock()
 	running := j.running
 	j.mu.RUnlock()
 
+	var exit int
 	if !running {
-		err := j.start()
-		exit := util.HandleExecErr(err)
-
-		j.mu.Lock()
-		j.exitCode = int(exit)
-		j.mu.Unlock()
-
-		j.finish()
+		if background {
+			exit, err = jobs.startBackground(j)
+		} else {
+			exit, err = jobs.runForeground(j)
+		}
 	}
 
-	return nil
+	mlr.PushNext1(moonlight.IntValue(int64(exit)))
+	return err
 }
 
 // #interface jobs
@@ -183,10 +324,10 @@ func luaStopJob(mlr *moonlight.Runtime) error {
 	}
 
 	j.mu.RLock()
-	running := j.running
+	active := j.running || j.suspended
 	j.mu.RUnlock()
 
-	if running {
+	if active {
 		j.stop()
 		j.finish()
 	}
@@ -197,8 +338,8 @@ func luaStopJob(mlr *moonlight.Runtime) error {
 // #interface jobs
 // #member
 // foreground()
-// Puts a job in the foreground. This will cause it to run like it was
-// executed normally and wait for it to complete.
+// Resumes a suspended or backgrounded job in the foreground. This will cause
+// it to run like it was executed normally and wait for it to complete.
 func luaForegroundJob(mlr *moonlight.Runtime) error {
 	if err := mlr.Check1Arg(); err != nil {
 		return err
@@ -210,42 +351,33 @@ func luaForegroundJob(mlr *moonlight.Runtime) error {
 	}
 
 	j.mu.RLock()
-	running := j.running
+	active := j.running || j.suspended
 	j.mu.RUnlock()
 
-	if !running {
+	if !active {
 		return errors.New("job not running")
 	}
 
-	// lua code can run in other threads and goroutines, so this exists
-	if jobs.foreground {
+	jobs.mu.Lock()
+	if jobs.current != nil {
+		jobs.mu.Unlock()
 		return errors.New("(another) job already foregrounded")
 	}
-
-	jobs.foreground = true
+	jobs.current = j
+	jobs.mu.Unlock()
 	defer func() {
-		jobs.foreground = false
+		jobs.mu.Lock()
+		jobs.current = nil
+		jobs.mu.Unlock()
 	}()
 
-	// this is kinda funny
-	// background continues the process incase it got suspended
-	err = j.background()
-	if err != nil {
-		return err
-	}
-
-	err = j.foreground()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return j.foreground()
 }
 
 // #interface jobs
 // #member
 // background()
-// Puts a job in the background. This acts the same as initially running a job.
+// Resumes a suspended job in the background.
 func luaBackgroundJob(mlr *moonlight.Runtime) error {
 	if err := mlr.Check1Arg(); err != nil {
 		return err
@@ -257,26 +389,21 @@ func luaBackgroundJob(mlr *moonlight.Runtime) error {
 	}
 
 	j.mu.RLock()
-	running := j.running
+	active := j.running || j.suspended
 	j.mu.RUnlock()
 
-	if !running {
+	if !active {
 		return errors.New("job not running")
 	}
 
-	err = j.background()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return j.background()
 }
 
 type jobHandler struct {
-	jobs       map[int]*job
-	latestID   int
-	foreground bool // if job currently in the foreground
-	mu         *sync.RWMutex
+	jobs     map[int]*job
+	latestID int
+	current  *job // unregistered foreground job
+	mu       *sync.RWMutex
 }
 
 func newJobHandler() *jobHandler {
@@ -287,35 +414,24 @@ func newJobHandler() *jobHandler {
 	}
 }
 
-func (j *jobHandler) add(cmd string, args []string, path string) *job {
-	j.mu.Lock()
-	defer j.mu.Unlock()
-
-	j.latestID++
-	jb := &job{
-		cmd:     cmd,
-		running: false,
-		id:      j.latestID,
-		args:    args,
-		path:    path,
-		cmdout:  os.Stdout,
-		cmderr:  os.Stderr,
-		stdout:  &bytes.Buffer{},
-		stderr:  &bytes.Buffer{},
-	}
+func (j *jobHandler) newJob(cmd string) *job {
+	jb := &job{cmd: cmd}
 	jb.ud = jobUserData(jb)
-
-	j.jobs[j.latestID] = jb
-	hooks.Emit("job.add", moonlight.UserDataValue(jb.ud))
-
 	return jb
 }
 
-func (j *jobHandler) getLatest() *job {
-	j.mu.RLock()
-	defer j.mu.RUnlock()
+// register puts the job in the job table
+// a foreground job (99% a normal running command) only gets registered once its suspended
+func (j *jobHandler) register(jb *job) {
+	j.mu.Lock()
+	if jb.id == 0 {
+		j.latestID++
+		jb.id = j.latestID
+	}
+	j.jobs[jb.id] = jb
+	j.mu.Unlock()
 
-	return j.jobs[j.latestID]
+	hooks.Emit("job.add", moonlight.UserDataValue(jb.ud))
 }
 
 func (j *jobHandler) disown(id int) error {
@@ -337,13 +453,51 @@ func (j *jobHandler) stopAll() {
 	defer j.mu.RUnlock()
 
 	for _, jb := range j.jobs {
+		jb.mu.RLock()
+		active := jb.running || jb.suspended
+		jb.mu.RUnlock()
+		if !active {
+			continue
+		}
 		// on exit, unix shell should send sighup to all jobs
-		if jb.running {
-			proc := jb.getProc()
-			proc.Signal(syscall.SIGHUP)
-			jb.wait() // waits for program to exit due to sighup
+		if jb.typ == jobProcess {
+			if jb.handle != nil && jb.handle.Process != nil {
+				jb.handle.Process.Signal(syscall.SIGHUP)
+				jb.handle.Wait() // waits for program to exit due to sighup
+			}
+		} else {
+			jb.stop()
 		}
 	}
+}
+
+func (jh *jobHandler) runForeground(jb *job) (int, error) {
+	jh.mu.Lock()
+	jh.current = jb
+	jh.mu.Unlock()
+	defer func() {
+		jh.mu.Lock()
+		jh.current = nil
+		jh.mu.Unlock()
+	}()
+
+	exit, err := jb.run(true)
+
+	jb.mu.Lock()
+	jb.exitCode = exit
+	suspended := jb.suspended
+	jb.mu.Unlock()
+
+	if suspended {
+		jh.register(jb)
+	}
+
+	return exit, err
+}
+
+func (jh *jobHandler) startBackground(jb *job) (int, error) {
+	jh.register(jb)
+	return jb.run(false)
 }
 
 // #interface jobs
@@ -352,12 +506,13 @@ func (j *jobHandler) stopAll() {
 Manage interactive jobs in Hilbish via Lua.
 
 Jobs are the name of background tasks/commands. A job can be started via
-interactive usage or with the functions defined below for use in external runners. */
+interactive usage or with the functions defined below for use in external runners.
+*/
 func (j *jobHandler) loader(mlr *moonlight.Runtime) *moonlight.Table {
 	jobMethods := moonlight.NewTable()
 	jFuncs := map[string]moonlight.Export{
 		"stop":       {Function: luaStopJob, ArgNum: 1, Variadic: false},
-		"start":      {Function: luaStartJob, ArgNum: 1, Variadic: false},
+		"start":      {Function: luaStartJob, ArgNum: 1, Variadic: true},
 		"foreground": {Function: luaForegroundJob, ArgNum: 1, Variadic: false},
 		"background": {Function: luaBackgroundJob, ArgNum: 1, Variadic: false},
 	}
@@ -383,16 +538,25 @@ func (j *jobHandler) loader(mlr *moonlight.Runtime) *moonlight.Table {
 			val = moonlight.StringValue(j.cmd)
 		case "running":
 			val = moonlight.BoolValue(j.running)
+		case "suspended":
+			val = moonlight.BoolValue(j.suspended)
 		case "id":
 			val = moonlight.IntValue(int64(j.id))
-		case "pid":
-			val = moonlight.IntValue(int64(j.pid))
 		case "exitCode":
 			val = moonlight.IntValue(int64(j.exitCode))
+		// pid/stdout/stderr only make sense for process jobs, nil otherwise
+		case "pid":
+			if j.typ == jobProcess {
+				val = moonlight.IntValue(int64(j.pid))
+			}
 		case "stdout":
-			val = moonlight.StringValue(j.stdout.String())
+			if j.typ == jobProcess && j.stdout != nil {
+				val = moonlight.StringValue(j.stdout.String())
+			}
 		case "stderr":
-			val = moonlight.StringValue(j.stderr.String())
+			if j.typ == jobProcess && j.stderr != nil {
+				val = moonlight.StringValue(j.stderr.String())
+			}
 		}
 		j.mu.RUnlock()
 
@@ -407,7 +571,7 @@ func (j *jobHandler) loader(mlr *moonlight.Runtime) *moonlight.Table {
 		"all":     {Function: j.luaAllJobs, ArgNum: 0, Variadic: false},
 		"last":    {Function: j.luaLastJob, ArgNum: 0, Variadic: false},
 		"get":     {Function: j.luaGetJob, ArgNum: 1, Variadic: false},
-		"add":     {Function: j.luaAddJob, ArgNum: 3, Variadic: false},
+		"add":     {Function: j.luaAddJob, ArgNum: 2, Variadic: false},
 		"disown":  {Function: j.luaDisownJob, ArgNum: 1, Variadic: false},
 		"stopAll": {Function: j.luaStopAll, ArgNum: 0, Variadic: false},
 	}
@@ -442,6 +606,24 @@ func jobUserData(j *job) *moonlight.UserData {
 	return moonlight.NewUserData(j, moonlight.ToTable(jobMeta))
 }
 
+func sinkReader(val moonlight.Value) io.Reader {
+	if ud, ok := val.TryUserData(); ok {
+		if s, ok := ud.Value().(*util.Sink); ok {
+			return s.RawReader()
+		}
+	}
+	return nil
+}
+
+func sinkWriter(val moonlight.Value) io.Writer {
+	if ud, ok := val.TryUserData(); ok {
+		if s, ok := ud.Value().(*util.Sink); ok {
+			return s.RawWriter()
+		}
+	}
+	return nil
+}
+
 // #interface jobs
 // get(id) -> @Job
 // Get a job object via its ID.
@@ -469,51 +651,125 @@ func (j *jobHandler) luaGetJob(mlr *moonlight.Runtime) error {
 }
 
 // #interface jobs
-// add(cmdstr, args, execPath)
-// Creates a new job. This function does not run the job. This function is intended to be
-// used by runners, but can also be used to create jobs via Lua. Commanders cannot be ran as jobs.
+// add(cmdstr, opts) -> @Job
+// Creates a new job but does not run it. The job kind is decided by `opts`:
+// a process job is created from `args`/`path` (with optional `env`, `dir`
+// and `sinks`), while a lua/code job is created by supplying `run` (and
+// optionally `suspend`/`resume`) functions.
 // #param cmdstr string String that a user would write for the job
-// #param args table Arguments for the commands. Has to include the name of the command.
-// #param execPath string Binary to use to run the command. Needs to be an absolute path.
+// #param opts table Job options.
 /*
 #example
-hilbish.jobs.add('go build', {'go', 'build'}, '/usr/bin/go')
+-- a process job
+hilbish.jobs.add('go build', {
+	args = {'go', 'build'},
+	path = '/usr/bin/go',
+})
+
+-- a lua/code job (suspendable if the runner can handle it)
+hilbish.jobs.add('my task', {
+	run = function(job) --[[ ... ]] return 0 end,
+	suspend = function(job) --[[ pause ]] end,
+	resume = function(job, fg) --[[ resume ]] end,
+})
 #example
 */
 func (j *jobHandler) luaAddJob(mlr *moonlight.Runtime) error {
-	if err := mlr.CheckNArgs(3); err != nil {
+	if err := mlr.CheckNArgs(2); err != nil {
 		return err
 	}
 	cmd, err := mlr.StringArg(0)
 	if err != nil {
 		return err
 	}
-	largs, err := mlr.TableArg(1)
+	opts, err := mlr.TableArg(1)
 	if err != nil {
 		return err
 	}
-	execPath, err := mlr.StringArg(2)
-	if err != nil {
-		return err
+
+	jb := j.newJob(cmd)
+
+	// a run function means its a lua job, otherwise we build a process
+	runFn := opts.Get(moonlight.StringValue("run"))
+	if runFn != moonlight.NilValue {
+		jb.typ = jobLua
+		jb.runFn = runFn
+		jb.suspendFn = opts.Get(moonlight.StringValue("suspend"))
+		jb.resumeFn = opts.Get(moonlight.StringValue("resume"))
+		mlr.PushNext1(moonlight.UserDataValue(jb.ud))
+		return nil
 	}
 
 	var args []string
-	moonlight.ForEach(largs, func(k moonlight.Value, v moonlight.Value) {
-		if v.Type() == moonlight.StringType {
-			args = append(args, v.AsString())
-		}
-	})
+	if argsTbl, ok := moonlight.TryTable(opts.Get(moonlight.StringValue("args"))); ok {
+		moonlight.ForEach(argsTbl, func(k, v moonlight.Value) {
+			if v.Type() == moonlight.StringType {
+				args = append(args, v.AsString())
+			}
+		})
+	}
 
-	jb := j.add(cmd, args, execPath)
+	path := ""
+	if p, ok := opts.Get(moonlight.StringValue("path")).TryString(); ok {
+		path = p
+	}
+
+	var env []string
+	if envTbl, ok := moonlight.TryTable(opts.Get(moonlight.StringValue("env"))); ok {
+		moonlight.ForEach(envTbl, func(k, v moonlight.Value) {
+			if v.Type() != moonlight.StringType {
+				return
+			}
+			// support both { 'K=V', ... } and { K = 'V' }
+			if k.Type() == moonlight.StringType {
+				env = append(env, k.AsString()+"="+v.AsString())
+			} else {
+				env = append(env, v.AsString())
+			}
+		})
+	}
+
+	dir := ""
+	if d, ok := opts.Get(moonlight.StringValue("dir")).TryString(); ok {
+		dir = d
+	}
+
+	cmdout := io.Writer(os.Stdout)
+	cmderr := io.Writer(os.Stderr)
+	if sinks, ok := moonlight.TryTable(opts.Get(moonlight.StringValue("sinks"))); ok {
+		jb.stdin = sinkReader(sinks.Get(moonlight.StringValue("in")))
+		if w := sinkWriter(sinks.Get(moonlight.StringValue("out"))); w != nil {
+			cmdout = w
+		}
+		if w := sinkWriter(sinks.Get(moonlight.StringValue("err"))); w != nil {
+			cmderr = w
+		}
+	}
+
+	if c, ok := opts.Get(moonlight.StringValue("capture")).TryBool(); ok {
+		jb.capture = c
+	}
+
+	jb.typ = jobProcess
+	jb.path = path
+	jb.args = args
+	jb.env = env
+	jb.dir = dir
+	jb.cmdout = cmdout
+	jb.cmderr = cmderr
+	if jb.capture {
+		jb.stdout = &bytes.Buffer{}
+		jb.stderr = &bytes.Buffer{}
+	}
 
 	mlr.PushNext1(moonlight.UserDataValue(jb.ud))
 	return nil
 }
 
 // #interface jobs
-// all() -> table[@Job]
+// all() -> table<@Job>
 // Returns a table of all job objects.
-// #returns table[Job]
+// #returns table<Job>
 func (j *jobHandler) luaAllJobs(mlr *moonlight.Runtime) error {
 	j.mu.RLock()
 	defer j.mu.RUnlock()

--- a/job.go
+++ b/job.go
@@ -63,18 +63,23 @@ type job struct {
 	runFn     moonlight.Value
 	suspendFn moonlight.Value
 	resumeFn  moonlight.Value
-	done      chan int
+	done      chan luaJobResult
+}
+
+type luaJobResult struct {
+	code int
+	err  error
 }
 
 // run starts the job. foreground blocks until it exits or is suspended,
 // background reaps it in the back.
 func (j *job) run(foreground bool) (int, error) {
 	if j.typ == jobLua {
-		return j.runLua(foreground), nil
+		return j.runLua(foreground)
 	}
 
 	if err := j.startProc(); err != nil {
-		return int(util.HandleExecErr(err)), nil
+		return int(util.HandleExecErr(err)), err
 	}
 	if foreground {
 		return j.procForeground()
@@ -107,9 +112,10 @@ func (j *job) startProc() error {
 	j.handle = cmd
 
 	err := cmd.Start()
-	if cmd.Process != nil {
-		j.pid = cmd.Process.Pid
+	if err != nil {
+		return err
 	}
+	j.pid = cmd.Process.Pid
 
 	j.mu.Lock()
 	j.running = true
@@ -117,11 +123,11 @@ func (j *job) startProc() error {
 	j.mu.Unlock()
 
 	j.emitIfRegistered("job.start")
-	return err
+	return nil
 }
 
-func (j *job) runLua(foreground bool) int {
-	j.done = make(chan int, 1)
+func (j *job) runLua(foreground bool) (int, error) {
+	j.done = make(chan luaJobResult, 1)
 
 	j.mu.Lock()
 	j.running = true
@@ -139,30 +145,31 @@ func (j *job) runLua(foreground bool) int {
 				code = int(c)
 			}
 		}
-		j.done <- code
+		j.done <- luaJobResult{code: code, err: err}
 	}()
 
 	if foreground {
 		return j.awaitLua()
 	}
 	go j.awaitLua()
-	return 0
+	return 0, nil
 }
 
-func (j *job) awaitLua() int {
-	code := <-j.done
+func (j *job) awaitLua() (int, error) {
+	res := <-j.done
 
 	j.mu.Lock()
 	suspended := j.suspended
 	if !suspended {
 		j.running = false
 	}
+	j.exitCode = res.code
 	j.mu.Unlock()
 
 	if !suspended {
 		j.finish()
 	}
-	return code
+	return res.code, res.err
 }
 
 // suspend pauses the job. for a process this is sigstop, for a lua job its
@@ -229,10 +236,10 @@ func (j *job) resumeLua(foreground bool) error {
 		return err
 	}
 	if foreground {
-		j.awaitLua()
-	} else {
-		go j.awaitLua()
+		_, err := j.awaitLua()
+		return err
 	}
+	go j.awaitLua()
 	return nil
 }
 
@@ -329,7 +336,11 @@ func luaStopJob(mlr *moonlight.Runtime) error {
 
 	if active {
 		j.stop()
-		j.finish()
+		// process jobs are reaped by procWait, which calls finish()
+		// doing it here too would emit job.done twice
+		if j.typ != jobProcess {
+			j.finish()
+		}
 	}
 
 	return nil
@@ -463,7 +474,6 @@ func (j *jobHandler) stopAll() {
 		if jb.typ == jobProcess {
 			if jb.handle != nil && jb.handle.Process != nil {
 				jb.handle.Process.Signal(syscall.SIGHUP)
-				jb.handle.Wait() // waits for program to exit due to sighup
 			}
 		} else {
 			jb.stop()
@@ -700,18 +710,27 @@ func (j *jobHandler) luaAddJob(mlr *moonlight.Runtime) error {
 		return nil
 	}
 
-	var args []string
-	if argsTbl, ok := moonlight.TryTable(opts.Get(moonlight.StringValue("args"))); ok {
-		moonlight.ForEach(argsTbl, func(k, v moonlight.Value) {
-			if v.Type() == moonlight.StringType {
-				args = append(args, v.AsString())
-			}
-		})
+	path, hasPath := opts.Get(moonlight.StringValue("path")).TryString()
+	if !hasPath || path == "" {
+		return errors.New("process job requires a path")
 	}
 
-	path := ""
-	if p, ok := opts.Get(moonlight.StringValue("path")).TryString(); ok {
-		path = p
+	argsTbl, hasArgs := moonlight.TryTable(opts.Get(moonlight.StringValue("args")))
+	if !hasArgs || argsTbl.Len() == 0 {
+		return errors.New("process job requires args")
+	}
+
+	var args []string
+	var argErr error
+	moonlight.ForEach(argsTbl, func(k, v moonlight.Value) {
+		if v.Type() != moonlight.StringType {
+			argErr = fmt.Errorf("args table must only contain strings, got %s at index %s", v.TypeName(), moonlight.ToString(k))
+			return
+		}
+		args = append(args, v.AsString())
+	})
+	if argErr != nil {
+		return argErr
 	}
 
 	var env []string
@@ -736,8 +755,15 @@ func (j *jobHandler) luaAddJob(mlr *moonlight.Runtime) error {
 
 	cmdout := io.Writer(os.Stdout)
 	cmderr := io.Writer(os.Stderr)
+	jb.stdin = os.Stdin
 	if sinks, ok := moonlight.TryTable(opts.Get(moonlight.StringValue("sinks"))); ok {
-		jb.stdin = sinkReader(sinks.Get(moonlight.StringValue("in")))
+		in := sinks.Get(moonlight.StringValue("in"))
+		if in == moonlight.NilValue {
+			in = sinks.Get(moonlight.StringValue("input"))
+		}
+		if r := sinkReader(in); r != nil {
+			jb.stdin = r
+		}
 		if w := sinkWriter(sinks.Get(moonlight.StringValue("out"))); w != nil {
 			cmdout = w
 		}

--- a/job.go
+++ b/job.go
@@ -266,9 +266,9 @@ func (j *job) finish() {
 
 // only fire hooks for jobs actually in the table
 func (j *job) emitIfRegistered(event string) {
-	j.mu.RLock()
-	registered := j.id != 0
-	j.mu.RUnlock()
+	jobs.mu.RLock()
+	registered := jobs.jobs[j.id] == j
+	jobs.mu.RUnlock()
 
 	if registered {
 		hooks.Emit(event, moonlight.UserDataValue(j.ud))
@@ -453,15 +453,14 @@ func (j *jobHandler) register(jb *job) {
 }
 
 func (j *jobHandler) disown(id int) error {
-	j.mu.RLock()
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
 	if j.jobs[id] == nil {
 		return errors.New("job doesnt exist")
 	}
-	j.mu.RUnlock()
 
-	j.mu.Lock()
 	delete(j.jobs, id)
-	j.mu.Unlock()
 
 	return nil
 }

--- a/job_unix.go
+++ b/job_unix.go
@@ -13,36 +13,58 @@ var bgProcAttr *syscall.SysProcAttr = &syscall.SysProcAttr{
 	Setpgid: true,
 }
 
-func (j *job) foreground() error {
+func (j *job) procForeground() (int, error) {
 	pgid, err := syscall.Getpgid(j.pid)
+	if err == nil {
+		hshPgid, herr := syscall.Getpgid(os.Getpid())
+		// tcsetpgrp - give the job's process group control of the terminal
+		if unix.IoctlSetPointerInt(0, unix.TIOCSPGRP, pgid) == nil && herr == nil {
+			// always give control of the terminal back to hilbish afterwards
+			defer unix.IoctlSetPointerInt(0, unix.TIOCSPGRP, hshPgid)
+		}
+	}
+
+	return j.procWait()
+}
+
+// wait4 with WUNTRACED so we actually get told when the process is stopped
+// (suspended). a normal Wait() only comes back once it exits
+func (j *job) procWait() (int, error) {
+	var status unix.WaitStatus
+	_, err := unix.Wait4(j.pid, &status, unix.WUNTRACED, nil)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	hshPgid, err := syscall.Getpgid(os.Getpid())
-	if err != nil {
-		return err
+	exitCode := 0
+	suspended := status.Stopped()
+	if status.Exited() {
+		exitCode = status.ExitStatus()
 	}
 
-	// tcsetpgrp - give the job's process group control of the terminal
-	if err := unix.IoctlSetPointerInt(0, unix.TIOCSPGRP, pgid); err != nil {
-		return err
+	j.mu.Lock()
+	j.running = false
+	j.suspended = suspended
+	j.exitCode = exitCode
+	j.mu.Unlock()
+
+	if !suspended {
+		j.finish()
 	}
-	// always give control of the terminal back to hilbish afterwards
-	defer unix.IoctlSetPointerInt(0, unix.TIOCSPGRP, hshPgid)
 
-	proc, _ := os.FindProcess(j.pid)
-	proc.Wait()
+	return exitCode, nil
+}
 
+func (j *job) procSuspend() error {
+	if j.handle != nil && j.handle.Process != nil {
+		return j.handle.Process.Signal(syscall.SIGSTOP)
+	}
 	return nil
 }
 
-func (j *job) background() error {
-	proc := j.handle.Process
-	if proc == nil {
-		return nil
+func (j *job) procContinue() error {
+	if j.handle != nil && j.handle.Process != nil {
+		return j.handle.Process.Signal(syscall.SIGCONT)
 	}
-
-	proc.Signal(syscall.SIGCONT)
 	return nil
 }

--- a/job_unix.go
+++ b/job_unix.go
@@ -55,16 +55,17 @@ func (j *job) procWait() (int, error) {
 	return exitCode, nil
 }
 
-func (j *job) procSuspend() error {
-	if j.handle != nil && j.handle.Process != nil {
-		return j.handle.Process.Signal(syscall.SIGSTOP)
+func signalProcessGroup(j *job, sig syscall.Signal) error {
+	if j.handle == nil || j.handle.Process == nil {
+		return nil
 	}
-	return nil
+	return syscall.Kill(-j.handle.Process.Pid, sig)
+}
+
+func (j *job) procSuspend() error {
+	return signalProcessGroup(j, syscall.SIGSTOP)
 }
 
 func (j *job) procContinue() error {
-	if j.handle != nil && j.handle.Process != nil {
-		return j.handle.Process.Signal(syscall.SIGCONT)
-	}
-	return nil
+	return signalProcessGroup(j, syscall.SIGCONT)
 }

--- a/job_windows.go
+++ b/job_windows.go
@@ -5,16 +5,42 @@ package main
 import (
 	"errors"
 	"syscall"
+
+	"github.com/sammy-ette/hilbish/util"
 )
 
 var bgProcAttr *syscall.SysProcAttr = &syscall.SysProcAttr{
 	CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
 }
 
-func (j *job) foreground() error {
-	return errors.New("not supported on windows")
+// windows has no stop/cont, so foreground just runs and waits and there's no
+// suspending
+func (j *job) procForeground() (int, error) {
+	return j.procWait()
 }
 
-func (j *job) background() error {
-	return errors.New("not supported on windows")
+func (j *job) procWait() (int, error) {
+	if j.handle == nil {
+		return 0, errors.New("no process handle")
+	}
+
+	err := j.handle.Wait()
+	exit := int(util.HandleExecErr(err))
+
+	j.mu.Lock()
+	j.running = false
+	j.exitCode = exit
+	j.mu.Unlock()
+
+	j.finish()
+
+	return exit, nil
+}
+
+func (j *job) procSuspend() error {
+	return errors.New("job suspension not supported on windows")
+}
+
+func (j *job) procContinue() error {
+	return errors.New("job resume not supported on windows")
 }

--- a/nature/opts/notifyJobFinish.lua
+++ b/nature/opts/notifyJobFinish.lua
@@ -4,13 +4,13 @@ local lunacolors = require 'lunacolors'
 bait.catch('job.done', function(job)
 	if not hilbish.opts.notifyJobFinish then return end
 	local notifText = string.format(lunacolors.format [[
-Background job with ID#%d has exited (PID %d).
-Command string: {bold}{yellow}%s{reset}]], job.id, job.pid, job.cmd)
+Background job with ID#%d has exited (PID %s).
+Command string: {bold}{yellow}%s{reset}]], job.id, tostring(job.pid or '-'), job.cmd)
 
-	if job.stdout ~= '' then
+	if job.stdout and job.stdout ~= '' then
 		notifText = notifText .. '\n\nStandard output:\n' .. job.stdout
 	end
-	if job.stderr ~= '' then
+	if job.stderr and job.stderr ~= '' then
 		notifText = notifText .. '\n\nStandard error:\n' .. job.stderr
 	end
 

--- a/signal_unix.go
+++ b/signal_unix.go
@@ -10,8 +10,8 @@ import (
 
 func handleSignals() {
 	c := make(chan os.Signal, 1)
-	signal.Ignore(syscall.SIGTTOU, syscall.SIGTTIN, syscall.SIGTSTP)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGWINCH, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGQUIT)
+	signal.Ignore(syscall.SIGTTOU, syscall.SIGTTIN)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGWINCH, syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGQUIT, syscall.SIGTSTP)
 
 	for s := range c {
 		switch s {
@@ -19,6 +19,8 @@ func handleSignals() {
 			hooks.Emit("signal.sigint")
 		case syscall.SIGTERM:
 			exit(0)
+		case syscall.SIGTSTP:
+			suspendCurrentJob()
 		case syscall.SIGWINCH:
 			hooks.Emit("signal.resize")
 		case syscall.SIGUSR1:
@@ -26,5 +28,21 @@ func handleSignals() {
 		case syscall.SIGUSR2:
 			hooks.Emit("signal.sigusr2")
 		}
+	}
+}
+
+func suspendCurrentJob() {
+	if jobs == nil {
+		return
+	}
+	jobs.mu.RLock()
+	cur := jobs.current
+	jobs.mu.RUnlock()
+
+	if cur == nil {
+		return
+	}
+	if cur.typ == jobLua {
+		cur.suspend()
 	}
 }

--- a/types/fs.lua
+++ b/types/fs.lua
@@ -10,7 +10,7 @@
 ---@field glob fun(pattern: string): table
 ---@field join fun(...: string): string
 ---@field mkdir fun(name: string, recursive: boolean)
----@field pipe fun(): file*, file*
+---@field pipe fun(): Sink, Sink
 ---@field readdir fun(dir: string): table
 ---@field stat fun(path: string): table
 local fs = {}

--- a/types/hilbish.lua
+++ b/types/hilbish.lua
@@ -38,6 +38,7 @@ function Sink:writeln(str) end
 ---@class Job
 ---@field cmd any
 ---@field running any
+---@field suspended any
 ---@field id any
 ---@field pid any
 ---@field exitCode any
@@ -49,12 +50,12 @@ function Job:background() end
 
 function Job:foreground() end
 
-function Job:start() end
+function Job:start(opts) end
 
 function Job:stop() end
 
 ---@class hilbish.jobs
----@field add fun(cmdstr: string, args: table, execPath: string)
+---@field add fun(cmdstr: string, opts: table): Job
 ---@field all fun(): table<Job>
 ---@field disown fun(id: number)
 ---@field get fun(id: any): Job
@@ -129,6 +130,7 @@ function Timer:stop() end
 ---@field exitCode any
 ---@field running any
 ---@field initialized any
+---@field midnightEdition any
 ---@field home string
 ---@field editor Readline
 ---@field snail Snail

--- a/util/sink.go
+++ b/util/sink.go
@@ -18,8 +18,22 @@ var sinkMetaKey = moonlight.StringValue("hshsink")
 type Sink struct {
 	Rw        *bufio.ReadWriter
 	file      *os.File
+	reader    io.Reader // raw underlying reader, before bufio wrapping
+	writer    io.Writer // raw underlying writer, before bufio wrapping
 	UserData  *moonlight.UserData
 	autoFlush bool
+}
+
+// RawReader gives back the raw reader the sink wraps, before the bufio layer.
+// for handing to something that buffers on its own, like an exec.Cmd stdin
+func (s *Sink) RawReader() io.Reader {
+	return s.reader
+}
+
+// RawWriter gives back the raw writer the sink wraps, before the bufio layer.
+// for handing to something that buffers on its own, like an exec.Cmd stdout
+func (s *Sink) RawWriter() io.Writer {
+	return s.writer
 }
 
 func SinkLoader(mlr *moonlight.Runtime) *moonlight.Table {
@@ -240,6 +254,8 @@ func luaSinkAutoFlush(mlr *moonlight.Runtime) error {
 func NewSink(mlr *moonlight.Runtime, Rw io.ReadWriter) *Sink {
 	s := &Sink{
 		Rw:        bufio.NewReadWriter(bufio.NewReader(Rw), bufio.NewWriter(Rw)),
+		reader:    Rw,
+		writer:    Rw,
 		autoFlush: true,
 	}
 	s.UserData = sinkUserData(mlr, s)
@@ -253,7 +269,8 @@ func NewSink(mlr *moonlight.Runtime, Rw io.ReadWriter) *Sink {
 
 func NewSinkInput(mlr *moonlight.Runtime, r io.Reader) *Sink {
 	s := &Sink{
-		Rw: bufio.NewReadWriter(bufio.NewReader(r), nil),
+		Rw:     bufio.NewReadWriter(bufio.NewReader(r), nil),
+		reader: r,
 	}
 	s.UserData = sinkUserData(mlr, s)
 
@@ -267,6 +284,7 @@ func NewSinkInput(mlr *moonlight.Runtime, r io.Reader) *Sink {
 func NewSinkOutput(mlr *moonlight.Runtime, w io.Writer) *Sink {
 	s := &Sink{
 		Rw:        bufio.NewReadWriter(nil, bufio.NewWriter(w)),
+		writer:    w,
 		autoFlush: true,
 	}
 	s.UserData = sinkUserData(mlr, s)


### PR DESCRIPTION
when snail (sh runner) was detatched from the main hilbish code, job management was essentially gone. i have been thinking about how to handle job management in an agnostic way so that it is not snail specific, and this is the solution.

closes #317 